### PR TITLE
Ensure original material color is valid six digit hex string

### DIFF
--- a/src/main/webapp/js/GEPPETTO.js
+++ b/src/main/webapp/js/GEPPETTO.js
@@ -318,7 +318,7 @@ define(function(require) {
 						shading: THREE.SmoothShading
 					});
 
-				material.originalColor = '0x' + (Math.random() * 0xFFFFFF << 0).toString(16);
+				material.originalColor = '0x' + (0x1000000+(Math.random())*0xffffff).toString(16).substr(1,6);
 				material.color.setHex(material.originalColor);
 				return material;
 			};


### PR DESCRIPTION
I believe this should fix [#23](https://github.com/openworm/org.geppetto/issues/23), but there could be something else going on as well.
