### PR TITLE
Issue #34: Changed WebGL renderer to a singleton to resolve camera displacement issue on Chrome OSX.

### DIFF
--- a/src/main/webapp/js/GEPPETTO.Init.js
+++ b/src/main/webapp/js/GEPPETTO.Init.js
@@ -66,10 +66,15 @@ define(function(require) {
 		 * Set up the WebGL Renderer
 		 */
 		var setupRenderer = function() {
-			VARS.renderer = new THREE.WebGLRenderer(
-				{
-					antialias: true
-				});
+
+			// Reuse a single WebGL renderer. Recreating the renderer causes camera displacement on Chrome OSX.
+			if (!VARS.canvasCreated) {
+				VARS.renderer = new THREE.WebGLRenderer(
+					{
+						antialias: true
+					});
+			}
+
 			VARS.renderer.setClearColor(0x000000, 1);
 			var width = $(VARS.container).width();
 			var height = $(VARS.container).height();


### PR DESCRIPTION
Hello,

This is my first attempt at a contribution so definitely please let me know if you'd like me to change anything.

It's a small change to GEPPETTO.Init.js to address issue #34. It forces reuse of the WebGL context. I'm not sure why reusing the context causes camera displacement on Chrome OSX.

On my machine (Retina MacBook Pro) the displacement happens after the 3rd scene load. And then the camera displaces more after each subsequent scene load.

Please let me know if you have any questions or if you'd like me to make any changes.

Thanks!
David Frenkiel