### PR TITLE
Many improvements to the connectivity widget

### DIFF
--- a/src/main/webapp/js/widgets/buttonBar/ButtonBar.js
+++ b/src/main/webapp/js/widgets/buttonBar/ButtonBar.js
@@ -194,7 +194,9 @@ define(function(require) {
 						success : function(data) {
 							barDef = data;
 						},
-						error : function() {
+						error: function(xhr, status, error) {
+						  	var err = JSON.parse(xhr.responseText)
+						  	alert(err.Message);
 							GEPPETTO.Console.log('Warning: could not read bar from ' + url + '. Using default.');
 							barDef = that.sample;
 						},

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.css
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.css
@@ -37,10 +37,10 @@
 .legendTitle{
     font-size: 14px;
   }
-#filters{
+.connectivity-ordering{
 	position: absolute;
 }
-.filtersLabel{
+.connectivity-ordering-label{
 	margin-left:2px;
 	font-size: 12px;
     font-weight:100;

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.css
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.css
@@ -30,11 +30,11 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  *******************************************************************************/
-.legend {
+.legend-text {
     font-size: 12px;
     font-weight:100;
   }
-.legendTitle{
+.legend-title{
     font-size: 14px;
   }
 .connectivity-ordering{

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -69,14 +69,10 @@ define(function(require) {
 				//TODO: To subtract 20px is horrible and has to be replaced but I have no idea about how to calculate it
 				var width = this.size.width - 20;
 				var height = this.size.height - 20;
-				if (this.options.connectivityLayout == 'force'){
-					this.svg.attr("width", width).attr("height", height);
-					this.force.size([width, height]).resume();
-				}
-				else if (this.options.connectivityLayout == 'matrix') {
+				if (this.options.connectivityLayout == 'matrix') {
 					$('#' + this.id + '-ordering').remove();
-					this.createLayout();
 				}
+                this.createLayout();
 			}
 		},
 		
@@ -97,6 +93,7 @@ define(function(require) {
 		},
 		
 		createDataFromConnections: function(){
+
 			conn2nodeType = function(conn){return conn.getId().split('_')[0]};
 			conn2linkWeight = function(conn){return conn.getSubNodesOfDomainType('Synapse')[0].GBase.value};
 			conn2linkType = function(conn){return conn.getSubNodesOfDomainType('Synapse')[0].id};
@@ -198,14 +195,14 @@ define(function(require) {
                     .attr("cy", function(d) { return d.y; });
             });
             
-            var legendPosition = {x:  0.7 * this.options.innerWidth, y: 0};
+            var legendPosition = {x:  0.75 * this.options.innerWidth, y: 0};
 
             //Nodes
-            var legendBottom = this.createLegend('legend', nodeTypeScale, legendPosition, 'Nodes - Cell Types');
+            var legendBottom = this.createLegend('legend', nodeTypeScale, legendPosition, 'Cell Types');
            
             legendPosition.y = legendBottom.y + 10
             //Links
-            this.createLegend('legend2', linkTypeScale,  legendPosition, 'Links - Synapse Types');
+            this.createLegend('legend2', linkTypeScale,  legendPosition, 'Synapse Types');
         },
 
 
@@ -372,10 +369,9 @@ define(function(require) {
 
         	var horz, vert; 
 
-        	var legend = this.svg.selectAll(id)
+        	var legendItem = this.svg.selectAll(id)
                         .data(colorScale.domain())
                       .enter().append('g')
-                        .attr('class', 'legend')
                         .attr('transform', function(d, i) {
                             var height = colorBox.size + colorBox.labelSpace;
                             horz = colorBox.size + position.x + padding.x;
@@ -384,24 +380,24 @@ define(function(require) {
                         });
         
         	// coloured squares 
-        	legend.append('rect')
+        	legendItem.append('rect')
         		.attr('width', colorBox.size)
         		.attr('height', colorBox.size)
         		.style('fill', function(d) {return colorScale(d); })
         		.style('stroke', function(d) {return colorScale(d); });
         	
         	// labels
-        	legend.append('text')
+        	legendItem.append('text')
         		.attr('x', colorBox.size + colorBox.labelSpace)
         		.attr('y', colorBox.size - colorBox.labelSpace)
-        		.attr('class', 'legend')
+        		.attr('class', 'legend-text')
         		.text(function(d) { return d; });
 
         	// title
         	if(typeof title != 'undefined'){
-                    this.svg.append('text')
+                   this.svg.append('text')
                         .text(title)
-                        .attr('class', 'legendTitle')
+                        .attr('class', 'legend-title')
                         .attr('x', position.x + 2 * padding.x) 
                         .attr('y', position.y +  0.75 * padding.y);
         	}

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -142,7 +142,7 @@ define(function(require) {
 		},
 		
 		createLayout: function(){
-			$("svg").remove();
+			$('#' + this.id + " svg").remove();
 			
 			this.options.innerWidth = this.connectivityContainer.innerWidth() - this.widgetMargin;
 			this.options.innerHeight = this.connectivityContainer.innerHeight() - this.widgetMargin;

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -175,11 +175,11 @@ define(function(require) {
 		    				.domain(_.pluck(this.dataset.links, 'nodeType'));
 		    var weightScale = d3.scale.linear()
 		    				.domain(d3.extent(_.pluck(this.dataset.links, 'weight').map(parseFloat)))
-		    				.range([0,5]);
+		    				.range([0,4]);
 			
 		    this.force = d3.layout.force()
 		        .charge(-250)
-		        .linkDistance(100)
+		        .linkDistance(150)
 		        .size([this.options.innerWidth, this.options.innerHeight]);
 
 		        
@@ -319,7 +319,7 @@ define(function(require) {
 		    
 		    // Convert links to matrix; count pre / post conns.
 		    this.dataset.links.forEach(function(link) {
-		    	matrix[link.source][link.target].z = link.weight ? link.synapse_type : 0;
+		    	matrix[link.source][link.target].z = link.weight ? link.linkType : 0;
 		    	nodes[link.source].pre_count += 1;
 		    	nodes[link.target].post_count += 1;
 		    });

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -39,465 +39,416 @@
 
 define(function(require) {
 
-	var Widget = require('widgets/Widget');
-	var $ = require('jquery');
+    var Widget = require('widgets/Widget');
+    var $ = require('jquery');
 
-	return Widget.View.extend({
-		
-		dataset: {},
-		
-		defaultConnectivityOptions:  {
-			width: 660,
-			height: 500,
-			connectivityLayout: "matrix", //[matrix, hive, force]
-		},
-		
-		initialize : function(options){
-			this.options = options;
-			Widget.View.prototype.initialize.call(this,options);
-			this.setOptions(this.defaultConnectivityOptions);
-			
-			this.render();
-			this.setSize(options.height, options.width);
-			
-			this.connectivityContainer = $("#" +this.id);
-			this.connectivityContainer.on("dialogresizestop", function(event, ui) {
-			    //TODO: To subtract 20px is horrible and has to be replaced but I have no idea about how to calculate it
-				var width = $(this).innerWidth()-20;
-				var height = $(this).innerHeight()-20;
-				if (window[this.id].options.connectivityLayout == 'force'){
-					window[this.id].svg.attr("width", width).attr("height", height);
-					window[this.id].force.size([width, height]).resume();
-				}
-				else if (window[this.id].options.connectivityLayout == 'matrix') {
-					window[this.id].createLayout();
-				}
-				event.stopPropagation();
-		    });
-		},
-		
-		setData : function(root, options){
-			this.setOptions(options);
+    return Widget.View.extend({
+        
+        dataset: {},
+        
+        defaultConnectivityOptions:  {
+            width: 660,
+            height: 500,
+            connectivityLayout: "matrix", //[matrix, hive, force]
+        },
+        
+        initialize : function(options){
+            this.options = options;
+            Widget.View.prototype.initialize.call(this,options);
+            this.setOptions(this.defaultConnectivityOptions);
+            
+            this.render();
+            this.setSize(options.height, options.width);
+            
+            this.connectivityContainer = $("#" +this.id);
+            this.connectivityContainer.on("dialogresizestop", function(event, ui) {
+                //TODO: To subtract 20px is horrible and has to be replaced but I have no idea about how to calculate it
+                var width = $(this).innerWidth()-20;
+                var height = $(this).innerHeight()-20;
+                if (window[this.id].options.connectivityLayout == 'force'){
+                    window[this.id].svg.attr("width", width).attr("height", height);
+                    window[this.id].force.size([width, height]).resume();
+                }
+                else if (window[this.id].options.connectivityLayout == 'matrix') {
+                    window[this.id].createLayout();
+                }
+                event.stopPropagation();
+            });
+        },
+        
+        setData : function(root, options){
+            this.setOptions(options);
+            this.dataset = {};
+            this.mapping = {};
+            this.mappingSize = 0;
+            this.dataset["root"] = root;
+            this.widgetMargin = 20;
+            
+            this.createDataFromConnections();
+            
+            this.createLayout();
+            
+            //return "Metadata or variables added to connectivity widget";
+            return this;
+        },
+        
+        
+        createDataFromConnections: function(){
+            if (this.dataset["root"]._metaType == "EntityNode"){
+                var subEntities = this.dataset["root"].getEntities();
+                
+                this.dataset["nodes"] = [];
+                this.dataset["links"] = [];
+//                  this.dataset["graph"] = new Array(1);
+//                  this.dataset["multigraph"] = false;
+//                  this.dataset["directed"] = true;
 
-			this.dataset = {};
-			this.mapping = {};
-			this.mappingSize = 0;
-			this.dataset["root"] = root;
-			this.widgetMargin = 20;
-			
-			this.createDataFromConnections();
-			
-			this.createLayout();
-			
-			//return "Metadata or variables added to connectivity widget";
-			return this;
-		},
-		
-		
-		createDataFromConnections: function(){
-			if (this.dataset["root"]._metaType == "EntityNode"){
-				var subEntities = this.dataset["root"].getEntities();
-				
-				this.dataset["nodes"] = [];
-				this.dataset["links"] = [];
-//					this.dataset["graph"] = new Array(1);
-//					this.dataset["multigraph"] = false;
-//					this.dataset["directed"] = true;
+                for (var subEntityIndex in subEntities){
+                    var connections = subEntities[subEntityIndex].getConnections();
+                    for (var connectionIndex in connections){
+                        var connectionItem = connections[connectionIndex];
+                        if (connectionItem.getType() == "FROM"){
+                            var source = connectionItem.getParent().getId();
+                            var target = connectionItem.getEntityInstancePath().substring(connectionItem.getEntityInstancePath().indexOf('.') + 1);
+                            
+                            this.createNode(source);
+                            this.createNode(target);
+                            
+                            var linkItem = {};
+                            linkItem["source"] = this.mapping[source];
+                            linkItem["target"] = this.mapping[target];
+                            
+                            var customNodes = connectionItem.getCustomNodes();
+                            for (var customNodeIndex in connectionItem.getCustomNodes()){
+                                if ('getChildren' in customNodes[customNodeIndex]){
+                                    var customNodesChildren = customNodes[customNodeIndex].getChildren();
+                                    for (var customNodeChildIndex in customNodesChildren){
+                                        if (customNodesChildren[customNodeChildIndex].getId() == "Id"){
+                                            linkItem["linkType"] = customNodesChildren[customNodeChildIndex].getValue();
+                                        }
+                                        else if (customNodesChildren[customNodeChildIndex].getId() == "GBase"){
+                                            linkItem["weight"] = customNodesChildren[customNodeChildIndex].getValue();
+                                        }
+                                    }
+                                }
+                            }
+                            
+                            this.dataset["links"].push(linkItem);
+                        }
+                        
+                    }
+                }
+            }
+        },
+        
+        createLayout: function(){
+            $('#' + this.id + " svg").remove();
+            
+            this.options.innerWidth = this.connectivityContainer.innerWidth() - this.widgetMargin;
+            this.options.innerHeight = this.connectivityContainer.innerHeight() - this.widgetMargin;
+            
+            this.svg = d3.select("#"+this.id)
+                            .append("svg")
+                            .attr("width", this.options.innerWidth)
+                            .attr("height", this.options.innerHeight);
+            
+            if (this.options.connectivityLayout == 'matrix'){
+                $("#filters").remove();
+                this.createMatrixLayout();
+            }
+            else if (this.options.connectivityLayout == 'force') {
+                this.createForceLayout();
+            }
+        },
+        
+        createForceLayout: function(){
+            
+            //TODO: 20 categories hardcoded in color scales
+            var linkTypeScale = d3.scale.category20()
+                            .domain(_.pluck(this.dataset.links, 'linkType'));
+            var nodeTypeScale = d3.scale.category20()
+                            .domain(_.pluck(this.dataset.links, 'nodeType'));
+            var weightScale = d3.scale.linear()
+                            .domain(d3.extent(_.pluck(this.dataset.links, 'weight').map(parseFloat)))
+                            .range([0,4]);
+            
+            this.force = d3.layout.force()
+                .charge(-250)
+                .linkDistance(150)
+                .size([this.options.innerWidth, this.options.innerHeight]);
 
-				for (var subEntityIndex in subEntities){
-					var connections = subEntities[subEntityIndex].getConnections();
-					for (var connectionIndex in connections){
-						var connectionItem = connections[connectionIndex];
-						if (connectionItem.getType() == "FROM"){
-							var source = connectionItem.getParent().getId();
-							var target = connectionItem.getEntityInstancePath().substring(connectionItem.getEntityInstancePath().indexOf('.') + 1);
-							
-							this.createNode(source);
-							this.createNode(target);
-							
-							var linkItem = {};
-							linkItem["source"] = this.mapping[source];
-							linkItem["target"] = this.mapping[target];
-							
-							var customNodes = connectionItem.getCustomNodes();
-							for (var customNodeIndex in connectionItem.getCustomNodes()){
-								if ('getChildren' in customNodes[customNodeIndex]){
-									var customNodesChildren = customNodes[customNodeIndex].getChildren();
-									for (var customNodeChildIndex in customNodesChildren){
-										if (customNodesChildren[customNodeChildIndex].getId() == "Id"){
-											linkItem["linkType"] = customNodesChildren[customNodeChildIndex].getValue();
-										}
-										else if (customNodesChildren[customNodeChildIndex].getId() == "GBase"){
-											linkItem["weight"] = customNodesChildren[customNodeChildIndex].getValue();
-										}
-									}
-								}
-							}
-							
-							this.dataset["links"].push(linkItem);
-						}
-						
-					}
-				}
-			}
-		},
-		
-		createLayout: function(){
-			$('#' + this.id + " svg").remove();
-			
-			this.options.innerWidth = this.connectivityContainer.innerWidth() - this.widgetMargin;
-			this.options.innerHeight = this.connectivityContainer.innerHeight() - this.widgetMargin;
-			
-			this.svg = d3.select("#"+this.id)
-			                .append("svg")
-			                .attr("width", this.options.innerWidth)
-			                .attr("height", this.options.innerHeight);
-			
-			if (this.options.connectivityLayout == 'matrix'){
-				$("#filters").remove();
-				this.createMatrixLayout();
-			}
-			else if (this.options.connectivityLayout == 'force') {
-				this.createForceLayout();
-			}
-		},
-		
-		createForceLayout: function(){
+            this.force.nodes(this.dataset.nodes)
+                .links(this.dataset.links)
+                .start();
 
-			var legendRectSize = 20;
-			var legendSpacing = 4;
-			var sizeLegend = {width: 120};
-			var legendPos = this.options.innerWidth - sizeLegend.width;
-			
-			//TODO: 20 categories hardcoded in color scales
-		    var linkTypeScale = d3.scale.category20()
-		    				.domain(_.pluck(this.dataset.links, 'linkType'));
-		    var nodeTypeScale = d3.scale.category20()
-		    				.domain(_.pluck(this.dataset.links, 'nodeType'));
-		    var weightScale = d3.scale.linear()
-		    				.domain(d3.extent(_.pluck(this.dataset.links, 'weight').map(parseFloat)))
-		    				.range([0,4]);
-			
-		    this.force = d3.layout.force()
-		        .charge(-250)
-		        .linkDistance(150)
-		        .size([this.options.innerWidth, this.options.innerHeight]);
+            var link = this.svg.selectAll(".link")
+                .data(this.dataset.links)
+                .enter().append("line")
+                .attr("class", "link")
+                .style("stroke", function(d) {return linkTypeScale(d.linkType)})
+                .style("stroke-width", function(d) {return weightScale(d.weight)});
 
-		        
-		    this.force.nodes(this.dataset.nodes)
-	            .links(this.dataset.links)
-	            .start();
+            var node = this.svg.selectAll(".node")
+                .data(this.dataset.nodes)
+              .enter().append("circle")
+                .attr("class", "node")
+                .attr("r", 5)  // radius
+                .style("fill", function(d) {
+                    return nodeTypeScale(d.nodeType);
+                    return nodeTypeScale(d.id[0]);
+                })
+                .call(this.force.drag);
 
-	        var link = this.svg.selectAll(".link")
-	            .data(this.dataset.links)
-	            .enter().append("line")
-	            .attr("class", "link")
-	            .style("stroke", function(d) {return linkTypeScale(d.linkType)})
-	            .style("stroke-width", function(d) {return weightScale(d.weight)});
+            node.append("title")
+                .text(function(d) { return d.id; });
 
-	            
-	        var node = this.svg.selectAll(".node")
-	            .data(this.dataset.nodes)
-	            .enter().append("circle")
-	            .attr("class", "node")
-	            .attr("r", 5)  // radius
-	            .style("fill", function(d) {
-	                return nodeTypeScale(d.nodeType);
-//	            	console.log(d);
-	                return nodeTypeScale(d.id[0]);
-	            })
-	            .call(this.force.drag);
+            this.force.on("tick", function() {
+                link.attr("x1", function(d) { return d.source.x; })
+                    .attr("y1", function(d) { return d.source.y; })
+                    .attr("x2", function(d) { return d.target.x; })
+                    .attr("y2", function(d) { return d.target.y; });
 
-	        node.append("title")
-	            .text(function(d) { return d.id; });
+                node.attr("cx", function(d) { return d.x; })
+                    .attr("cy", function(d) { return d.y; });
+            });
+            
+            var legendWidth = 180;
+            var legendPosition = {x:  this.options.innerWidth - legendWidth, y: 0};
 
-	        this.force.on("tick", function() {
-	            link.attr("x1", function(d) { return d.source.x; })
-	                .attr("y1", function(d) { return d.source.y; })
-	                .attr("x2", function(d) { return d.target.x; })
-	                .attr("y2", function(d) { return d.target.y; });
 
-	            node.attr("cx", function(d) { return d.x; })
-	                .attr("cy", function(d) { return d.y; });
-	        });
-	        
-	      //LEGEND
-	        //NODES
-	        this.svg.append('text')
-	        	.text('Nodes - Cell Types')
-	        	.attr('class', 'legendTitle')
-	        	.attr('x', -2 * legendRectSize + legendPos)
-	        	.attr('y', legendRectSize + legendSpacing);
-	        
-	        var vertPosLegend = 0;
-		    var legend = this.svg.selectAll('.legend')
-		    	.data(nodeTypeScale.domain())
-		    	.enter()
-		    	.append('g')
-		    	.attr('class', 'legend')
-		    	.attr('transform', function(d, i) {
-				    var height = legendRectSize + legendSpacing;
-				    var offset = 2 * legendRectSize;
-				    var horz = -2 * legendRectSize + legendPos;
-				    vertPosLegend = i * height + offset;
-				    return 'translate(' + horz + ',' + vertPosLegend + ')';
-				  });
-		   this.createLegend(legend, nodeTypeScale, legendRectSize, legendSpacing);
-		    
-		  //LINKS
-	        this.svg.append('text')
-	        	.text('Links - Synapses Types')
-	        	.attr('class', 'legendTitle')
-	        	.attr('x', -2 * legendRectSize + legendPos)
-	        	.attr('y', vertPosLegend + 3 * legendRectSize);
-	        
-		    var legend = this.svg.selectAll('.legend2')
-		    	.data(linkTypeScale.domain())
-		    	.enter()
-		    	.append('g')
-		    	.attr('class', 'legend')
-		    	.attr('transform', function(d, i) {
-				    var height = legendRectSize + legendSpacing;
-				    var offset = vertPosLegend + 4 * legendRectSize;
-				    var horz = -2 * legendRectSize + legendPos;
-				    var vert = i * height + offset;
-				    return 'translate(' + horz + ',' + vert + ')';
-				  });
-		   this.createLegend(legend, linkTypeScale, legendRectSize, legendSpacing);
-		},
-		
-		createLegend: function(legend, colorScale, rectSize, spacing){
-		    legend.append('rect')
-		        .attr('width', rectSize)
-		        .attr('height', rectSize)
-		        .style('fill', function(d) {return colorScale(d); })
-		        .style('stroke', function(d) {return colorScale(d); });
-		    
-		    legend.append('text')
-		        .attr('x', rectSize + spacing)
-		        .attr('y', rectSize -  spacing)
-		        .attr('class', 'legend')
-		        .text(function(d) { return d; });
-			
-		},
-		
-		createMatrixLayout: function(){
-			var legendRectSize = 18;
-			var legendSpacing = 4;
-			var margin = {top: 30, right: 10, bottom: 10, left: 3};
-			var sizeLegend = {width: 120};
-			
-			var matrixDim = (this.options.innerHeight < (this.options.innerWidth - sizeLegend.width))?(this.options.innerHeight):(this.options.innerWidth - sizeLegend.width);
-			
-			var x = d3.scale.ordinal().rangeBands([0, matrixDim - margin.top]),
-	        // Opacity
-			z = d3.scale.linear().domain([0, 4]).clamp(true),
-			// Colors
-	        c = d3.scale.category10();
-			
-			this.svg
-			    .style("padding-left", margin.left + "px")
-			    .style("padding-top", margin.top + "px")
-			    .append("g")
-			    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-		    var matrix = [];
-		    var nodes = this.dataset.nodes;
-		    var root=this.dataset.root;
-		    var n = nodes.length;
+            //Nodes
+            var legendBottom = this.createLegend('legend', nodeTypeScale, legendPosition, 'Nodes - Cell Types');
+           
+            legendPosition.y = legendBottom.y + 10
+            //Links
+            this.createLegend('legend2', linkTypeScale,  legendPosition, 'Links - Synapse Types');
+        },
 
-		    // Compute index per node.
-		    nodes.forEach(function(node, i) {
-		    	node.pre_count = 0;
-		        node.post_count = 0;
-		        matrix[i] = d3.range(n).map(function(j) { return {x: j, y: i, z: 0}; });
-		    });
-		    
-		    // Convert links to matrix; count pre / post conns.
-		    this.dataset.links.forEach(function(link) {
-		    	matrix[link.source][link.target].z = link.weight ? link.linkType : 0;
-		    	nodes[link.source].pre_count += 1;
-		    	nodes[link.target].post_count += 1;
-		    });
 
-		    // Precompute the orders.
-		    var orders = {
-		        id: d3.range(n).sort(function(a, b) { return d3.ascending(nodes[a].id, nodes[b].id); }),
-		        community: d3.range(n).sort(function(a, b) { return nodes[b].community - nodes[a].community; }),
-		        pre_count: d3.range(n).sort(function(a, b) { return nodes[b].pre_count - nodes[a].pre_count; }),
-		        post_count: d3.range(n).sort(function(a, b) { return nodes[b].post_count - nodes[a].post_count; }),
-		    };
-		    
-//		    TODO: Commented it out until we have Louvain Community detection was implemented
-//		    var colours = {
-//		            id: function(d) {return c(d.z);},
-//		            community: function(d) {return nodes[d.x].community == nodes[d.y].community ? c(nodes[d.x].community) : null;},
-//		    };
+        createLegend: function(id, colorScale, position, title){
 
-		    // The default sort order.
-		    x.domain(orders.id);
-		    
+        	//TODO: boxes should scale based on number of items 
+        	var colorBox = {size : 20, labelSpace : 4};
+        	var padding = {x: colorBox.size, y: 2 * colorBox.size}
 
-		    var rect = this.svg.append("rect")
-		                        .attr("class", "background")
-		                        .attr("width", matrixDim - margin.left)
-		                        .attr("height", matrixDim - margin.top);
+        	var horz, vert; 
 
-		        
-		    var row = this.svg.selectAll(".row")
-		          .data(matrix)
-		        .enter().append("g")
-		          .attr("class", "row")
-		          .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
-		          .each(row);
+        	var legend = this.svg.selectAll(id)
+                        .data(colorScale.domain())
+                      .enter().append('g')
+                        .attr('class', 'legend')
+                        .attr('transform', function(d, i) {
+                            var height = colorBox.size + colorBox.labelSpace;
+                            horz = colorBox.size + position.x + padding.x;
+                            vert = i * height + position.y + padding.y;
+                            return 'translate(' + horz + ',' + vert + ')';
+                        });
+        
+        	// coloured squares 
+        	legend.append('rect')
+        		.attr('width', colorBox.size)
+        		.attr('height', colorBox.size)
+        		.style('fill', function(d) {return colorScale(d); })
+        		.style('stroke', function(d) {return colorScale(d); });
+        	
+        	// labels
+        	legend.append('text')
+        		.attr('x', colorBox.size + colorBox.labelSpace)
+        		.attr('y', colorBox.size - colorBox.labelSpace)
+        		.attr('class', 'legend')
+        		.text(function(d) { return d; });
 
-		      row.append("line")
-		          .attr("x2", this.options.innerWidth);
-		      /*
-		      row.append("text")
-		          .attr("x", -6)
-		          .attr("y", x.rangeBand() / 2)
-		          .attr("dy", ".32em")
-		          .attr("text-anchor", "end")
-		          .text(function(d, i) {
-		        	  return nodes[i].id; 
-		        	  });*/
+        	// title
+        	if(typeof title != 'undefined'){
+                    this.svg.append('text')
+                        .text(title)
+                        .attr('class', 'legendTitle')
+                        .attr('x', position.x + 2 * padding.x) 
+                        .attr('y', position.y +  0.75 * padding.y);
+        	}
+        	
+        	return {x: horz, y: vert};
+        	
+        },
 
-		      var column = this.svg.selectAll(".column")
-		          .data(matrix)
-		        .enter().append("g")
-		          .attr("class", "column")
-		          .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
 
-		      column.append("line")
-		          .attr("x1", -this.options.innerWidth);
-		      /*
-		      column.append("text")
-		          .attr("x", 4)
-		          .attr("y", x.rangeBand() / 2)
-		          .attr("text-anchor", "start")
-		          .text(function(d, i) { 
-		        	  return nodes[i].id; 
-		        	  });*/
-		      
-		      var tooltip = this.svg
-			  	.append("text")
-			  	.attr("x", 0)
-			  	.attr("y", -10)
-			  	.attr('class', 'connectionlabel')
-			  	.text("Hover the squares to see the connections.");
-		    
-		    //LEGEND  
-		    var legend = this.svg.selectAll('.legend')
-		    	            .data(c.domain())
-		    	            .enter()
-		    	            .append('g')
-		    	            .attr('class', 'legend')
-		    	            .attr('transform', function(d, i) {
-				                var height = legendRectSize + legendSpacing;
-				                var offset = 0;
-				                var horz = matrixDim+5;
-				                var vert = i * height - offset;
-				                return 'translate(' + horz + ',' + vert + ')';
-				              });
-		    
-		   this.createLegend(legend, c, legendRectSize, legendSpacing);
-		    
-		    //FILTERS AND EVENTS
-		    this.connectivityContainer.append("<div id='filters' style='width:" + sizeLegend.width + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");
+        createMatrixLayout: function(){
+
+            var margin = {top: 30, right: 10, bottom: 10, left: 3};
+
+            var legendWidth = 120;
+
+            var matrixDim = (this.options.innerHeight < (this.options.innerWidth - legendWidth))?(this.options.innerHeight):(this.options.innerWidth - legendWidth);
+            
+            var x = d3.scale.ordinal().rangeBands([0, matrixDim - margin.top]),
+            // Opacity
+            z = d3.scale.linear().domain([0, 4]).clamp(true),
+            // Colors
+            c = d3.scale.category10();
+            
+            this.svg
+                .style("padding-left", margin.left + "px")
+                .style("padding-top", margin.top + "px")
+                .append("g")
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+            var matrix = [];
+            var nodes = this.dataset.nodes;
+            var root=this.dataset.root;
+            var n = nodes.length;
+
+            // Compute index per node.
+            nodes.forEach(function(node, i) {
+                node.pre_count = 0;
+                node.post_count = 0;
+                matrix[i] = d3.range(n).map(function(j) { return {x: j, y: i, z: 0}; });
+            });
+            
+            // Convert links to matrix; count pre / post conns.
+            this.dataset.links.forEach(function(link) {
+                matrix[link.source][link.target].z = link.weight ? link.linkType : 0;
+                nodes[link.source].pre_count += 1;
+                nodes[link.target].post_count += 1;
+            });
+
+            // Precompute the orders.
+            var orders = {
+                id: d3.range(n).sort(function(a, b) { return d3.ascending(nodes[a].id, nodes[b].id); }),
+                //community: d3.range(n).sort(function(a, b) { return nodes[b].community - nodes[a].community; }),
+                pre_count: d3.range(n).sort(function(a, b) { return nodes[b].pre_count - nodes[a].pre_count; }),
+                post_count: d3.range(n).sort(function(a, b) { return nodes[b].post_count - nodes[a].post_count; }),
+            };
+            
+//          TODO: Commented it out until we have Louvain Community detection was implemented
+//          var colours = {
+//                  id: function(d) {return c(d.z);},
+//                  community: function(d) {return nodes[d.x].community == nodes[d.y].community ? c(nodes[d.x].community) : null;},
+//          };
+
+            // The default sort order.
+            x.domain(orders.id);
+            
+            var rect = this.svg
+                          .append("rect")
+                            .attr("class", "background")
+                            .attr("width", matrixDim - margin.left)
+                            .attr("height", matrixDim - margin.top);
+
+                
+            var row = this.svg.selectAll(".row")
+                  .data(matrix)
+                .enter().append("g")
+                  .attr("class", "row")
+                  .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
+                  .each(row);
+
+            row.append("line")
+                  .attr("x2", this.options.innerWidth);
+
+            var column = this.svg.selectAll(".column")
+                  .data(matrix)
+                .enter().append("g")
+                  .attr("class", "column")
+                  .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
+
+            column.append("line")
+                    .attr("x1", -this.options.innerWidth);
+              
+            var tooltip = this.svg
+                .append("text")
+                  .attr("x", 0)
+                  .attr("y", -10)
+                  .attr('class', 'connectionlabel')
+                  .text("Hover the squares to see the connections.");
+            
+           this.createLegend('legend', c, {x: matrixDim, y:0});
+            
+            //FILTERS AND EVENTS
+		    this.connectivityContainer.append("<div id='filters' style='width:" + legendWidth + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");
 		    $('#filters').append("<span class='filtersLabel'>Select the ordering</span><select id='order'><option value='id'>by Entity Name</option><option value='pre_count'>by # pre</option><option value='post_count'>by # post</option></select>");
-//		    TODO: Commented it out once Louvain Community detection was implemented
-//		    $('#filters').append("<span class='filtersLabel'>Order:</span><select id='order'><option value='id'>by Cell Name</option><option value='community'>by Louvain Community </option><option value='pre_count'>by # pre</option><option value='post_count'>by # post</option></select>");
-//		    $('#filters').append("<span class='filtersLabel'>Colour:</span><select id='colour'><option value='id'>by Neuromodulator</option><option value='community'>by Louvain Community </option></select>");
-
-//			d3.select("#colour").on("change", function(svg) {
-//				return function() {
-//					svg.selectAll(".cell").style("fill", colours[this.value]);
-//				}
-//			}(this.svg));
-			   
-			d3.select('#' + this.id + ' order').on("change", function(svg) {
-				return function() {
-					x.domain(orders[this.value]);
-			
-			        var t = svg.transition().duration(2500);
-			        t.selectAll(".row")
-			            .delay(function(d, i) { return x(i) * 4; })
-			            .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
-			            .selectAll(".cell")
-			            .delay(function(d) { return x(d.x) * 4; })
-			            .attr("x", function(d) { return x(d.x); });
-			
-			        t.selectAll(".column")
-			            .delay(function(d, i) { return x(i) * 4; })
-			            .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
-				}
-			}(this.svg));
-		    
-		    // UTILITIES
-			function row(row) {
-				var cell = d3.select(this).selectAll(".cell")
-				    .data(row.filter(function(d) { return d.z;})) //only paint conns
-				    .enter().append("rect")
-				    .attr("class", "cell")
-				    .attr("x", function(d) { return x(d.x); })
-				    .attr("width", x.rangeBand())
-				    .attr("height", x.rangeBand())
-				    .attr("title", function(d) { return d.id;})
-				    .style("fill-opacity", function(d) { return z(d.z); })
-				    .style("fill", function(d) {return c(d.z); })
-					.on("click", function(d){
-						Simulation.unSelectAll();
-						//Ideally instead of hiding the connectivity lines we'd show only the ones connecting the two cells, also we could higlight the connection.
-						eval(root.name+"."+nodes[d.x].id).select();
-						eval(root.name+"."+nodes[d.x].id).showConnectionLines(false);
-						eval(root.name+"."+nodes[d.y].id).select();
-						eval(root.name+"."+nodes[d.y].id).showConnectionLines(false);
-						})
-				    .on("mouseover", function(d){
-				    	d3.select(this.parentNode.appendChild(this)).transition().duration(100).style({'stroke-opacity':1,'stroke':'white', 'stroke-width':'2'});
-				    	d3.select("body").style('cursor','pointer');
-						return tooltip.transition().duration(100).text(nodes[d.x].id + " is connected to " + nodes[d.y].id);
-						})
-					.on("mouseout", function(){
-						d3.select(this).transition().duration(100).style({'stroke-opacity':0,'stroke':'white'});
-						d3.select("body").style('cursor','default');
-						return tooltip.text("");
-						});
-			}
-			
-			
-			function mouseover(p) {
-				d3.selectAll(".row text").classed("active", function(d, i) { return i == p.y; });
-				d3.selectAll(".column text").classed("active", function(d, i) { return i == p.x; });
-			}
-			
-			function mouseout() {
-			    d3.selectAll("text").classed("active", false);
-			}
-		},
-		
-		createNode: function(nodeId) {
-			if (!(nodeId in this.mapping)){
-				var nodeItem = {};
-				nodeItem["id"] = nodeId;
-				this.dataset["nodes"].push(nodeItem);
-				
-				this.mapping[nodeItem["id"]] = this.mappingSize;
-				this.mappingSize++;
-			}
-		},
-		
-		/**
-		 *
-		 * Set the options for the connectivity widget
-		 *
-		 * @command setOptions(options)
-		 * @param {Object} options - options to modify the plot widget
-		 */
-		setOptions: function(options) {
-			if(options != null) {
-				$.extend(this.options, options);
-			}
-		},		
-	});
+               
+            d3.select('#order').on("change", function(svg) {
+                return function() {
+                    x.domain(orders[this.value]);
+            
+                    var t = svg.transition().duration(2500);
+                    t.selectAll(".row")
+                        .delay(function(d, i) { return x(i) * 4; })
+                        .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
+                        .selectAll(".cell")
+                        .delay(function(d) { return x(d.x) * 4; })
+                        .attr("x", function(d) { return x(d.x); });
+            
+                    t.selectAll(".column")
+                        .delay(function(d, i) { return x(i) * 4; })
+                        .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
+                }
+            }(this.svg));
+            
+            // UTILITIES
+            function row(row) {
+                var cell = d3.select(this).selectAll(".cell")
+                    .data(row.filter(function(d) { return d.z;})) //only paint conns
+                    .enter().append("rect")
+                    .attr("class", "cell")
+                    .attr("x", function(d) { return x(d.x); })
+                    .attr("width", x.rangeBand())
+                    .attr("height", x.rangeBand())
+                    .attr("title", function(d) { return d.id;})
+                    .style("fill-opacity", function(d) { return z(d.z); })
+                    .style("fill", function(d) {return c(d.z); })
+                    .on("click", function(d){
+                        Simulation.unSelectAll();
+                        //Ideally instead of hiding the connectivity lines we'd show only the ones connecting the two cells, also we could higlight the connection.
+                        eval(root.name+"."+nodes[d.x].id).select();
+                        eval(root.name+"."+nodes[d.x].id).showConnectionLines(false);
+                        eval(root.name+"."+nodes[d.y].id).select();
+                        eval(root.name+"."+nodes[d.y].id).showConnectionLines(false);
+                        })
+                    .on("mouseover", function(d){
+                        d3.select(this.parentNode.appendChild(this)).transition().duration(100).style({'stroke-opacity':1,'stroke':'white', 'stroke-width':'2'});
+                        d3.select("body").style('cursor','pointer');
+                        return tooltip.transition().duration(100).text(nodes[d.x].id + " is connected to " + nodes[d.y].id);
+                        })
+                    .on("mouseout", function(){
+                        d3.select(this).transition().duration(100).style({'stroke-opacity':0,'stroke':'white'});
+                        d3.select("body").style('cursor','default');
+                        return tooltip.text("");
+                        });
+            }
+            
+            
+            function mouseover(p) {
+                d3.selectAll(".row text").classed("active", function(d, i) { return i == p.y; });
+                d3.selectAll(".column text").classed("active", function(d, i) { return i == p.x; });
+            }
+            
+            function mouseout() {
+                d3.selectAll("text").classed("active", false);
+            }
+        },
+        
+        createNode: function(nodeId) {
+            if (!(nodeId in this.mapping)){
+                var nodeItem = {};
+                nodeItem["id"] = nodeId;
+                this.dataset["nodes"].push(nodeItem);
+                
+                this.mapping[nodeItem["id"]] = this.mappingSize;
+                this.mappingSize++;
+            }
+        },
+        
+        /**
+         *
+         * Set the options for the connectivity widget
+         *
+         * @command setOptions(options)
+         * @param {Object} options - options to modify the plot widget
+         */
+        setOptions: function(options) {
+            if(options != null) {
+                $.extend(this.options, options);
+            }
+        },      
+    });
 });

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -241,18 +241,7 @@ define(function(require) {
 				    vertPosLegend = i * height + offset;
 				    return 'translate(' + horz + ',' + vertPosLegend + ')';
 				  });
-		    
-		    
-		    legend.append('rect')
-		    .attr('width', legendRectSize)
-		    .attr('height', legendRectSize)
-		    .style('fill', function(d) {return nodeTypeScale(d); })
-		    .style('stroke', function(d) {return nodeTypeScale(d); });
-		    
-		    legend.append('text')
-		    .attr('x', legendRectSize + legendSpacing)
-		    .attr('y', legendRectSize - legendSpacing)
-		    .text(function(d) { return d; });
+		   this.createLegend(legend, nodeTypeScale, legendRectSize, legendSpacing);
 		    
 		  //LINKS
 	        this.svg.append('text')
@@ -273,17 +262,21 @@ define(function(require) {
 				    var vert = i * height + offset;
 				    return 'translate(' + horz + ',' + vert + ')';
 				  });
-		    
+		   this.createLegend(legend, linkTypeScale, legendRectSize, legendSpacing);
+		},
+		
+		createLegend: function(legend, colorScale, rectSize, spacing){
 		    legend.append('rect')
-		    .attr('width', legendRectSize)
-		    .attr('height', legendRectSize)
-		    .style('fill', function(d) {return linkTypeScale(d); })
-		    .style('stroke', function(d) {return linkTypeScale(d); });
+		    .attr('width', rectSize)
+		    .attr('height', rectSize)
+		    .style('fill', function(d) {return colorScale(d); })
+		    .style('stroke', function(d) {return colorScale(d); });
 		    
 		    legend.append('text')
-		    .attr('x', legendRectSize + legendSpacing)
-		    .attr('y', legendRectSize - legendSpacing)
+		    .attr('x', rectSize + spacing)
+		    .attr('y', rectSize - spacing)
 		    .text(function(d) { return d; });
+			
 		},
 		
 		createMatrixLayout: function(){
@@ -405,17 +398,7 @@ define(function(require) {
 				    return 'translate(' + horz + ',' + vert + ')';
 				  });
 		    
-		    legend.append('rect')
-		    .attr('width', legendRectSize)
-		    .attr('height', legendRectSize)
-		    .style('fill', function(d) {return c(d); })
-		    .style('stroke', function(d) {return c(d); });
-		    
-		    legend.append('text')
-		    .attr('x', legendRectSize + legendSpacing)
-		    .attr('y', legendRectSize - legendSpacing)
-		    .attr('class', 'legend')
-		    .text(function(d) { return d; });
+		   this.createLegend(legend, c, legendRectSize, legendSpacing);
 		    
 		    //FILTERS AND EVENTS
 		    this.connectivityContainer.append("<div id='filters' style='width:" + sizeLegend.width + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -148,9 +148,10 @@ define(function(require) {
 			this.options.innerWidth = this.connectivityContainer.innerWidth() - this.widgetMargin;
 			this.options.innerHeight = this.connectivityContainer.innerHeight() - this.widgetMargin;
 			
-			this.svg = d3.select("#"+this.id).append("svg")
-            .attr("width", this.options.innerWidth)
-            .attr("height", this.options.innerHeight);
+			this.svg = d3.select("#"+this.id)
+			                .append("svg")
+			                .attr("width", this.options.innerWidth)
+			                .attr("height", this.options.innerHeight);
 			
 			if (this.options.connectivityLayout == 'matrix'){
 				$("#filters").remove();
@@ -267,15 +268,16 @@ define(function(require) {
 		
 		createLegend: function(legend, colorScale, rectSize, spacing){
 		    legend.append('rect')
-		    .attr('width', rectSize)
-		    .attr('height', rectSize)
-		    .style('fill', function(d) {return colorScale(d); })
-		    .style('stroke', function(d) {return colorScale(d); });
+		        .attr('width', rectSize)
+		        .attr('height', rectSize)
+		        .style('fill', function(d) {return colorScale(d); })
+		        .style('stroke', function(d) {return colorScale(d); });
 		    
 		    legend.append('text')
-		    .attr('x', rectSize + spacing)
-		    .attr('y', rectSize - spacing)
-		    .text(function(d) { return d; });
+		        .attr('x', rectSize + spacing)
+		        .attr('y', rectSize -  spacing)
+		        .attr('class', 'legend')
+		        .text(function(d) { return d; });
 			
 		},
 		
@@ -294,10 +296,10 @@ define(function(require) {
 	        c = d3.scale.category10();
 			
 			this.svg
-			.style("padding-left", margin.left + "px")
-			.style("padding-top", margin.top + "px")
-			.append("g")
-			.attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+			    .style("padding-left", margin.left + "px")
+			    .style("padding-top", margin.top + "px")
+			    .append("g")
+			    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 		    var matrix = [];
 		    var nodes = this.dataset.nodes;
 		    var root=this.dataset.root;
@@ -336,9 +338,9 @@ define(function(require) {
 		    
 
 		    var rect = this.svg.append("rect")
-		          .attr("class", "background")
-		          .attr("width", matrixDim - margin.left)
-		          .attr("height", matrixDim - margin.top);
+		                        .attr("class", "background")
+		                        .attr("width", matrixDim - margin.left)
+		                        .attr("height", matrixDim - margin.top);
 
 		        
 		    var row = this.svg.selectAll(".row")
@@ -386,17 +388,17 @@ define(function(require) {
 		    
 		    //LEGEND  
 		    var legend = this.svg.selectAll('.legend')
-		    	.data(c.domain())
-		    	.enter()
-		    	.append('g')
-		    	.attr('class', 'legend')
-		    	.attr('transform', function(d, i) {
-				    var height = legendRectSize + legendSpacing;
-				    var offset = 0;
-				    var horz = matrixDim+5;
-				    var vert = i * height - offset;
-				    return 'translate(' + horz + ',' + vert + ')';
-				  });
+		    	            .data(c.domain())
+		    	            .enter()
+		    	            .append('g')
+		    	            .attr('class', 'legend')
+		    	            .attr('transform', function(d, i) {
+				                var height = legendRectSize + legendSpacing;
+				                var offset = 0;
+				                var horz = matrixDim+5;
+				                var vert = i * height - offset;
+				                return 'translate(' + horz + ',' + vert + ')';
+				              });
 		    
 		   this.createLegend(legend, c, legendRectSize, legendSpacing);
 		    

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -34,7 +34,7 @@
  * Tree Visualiser Widget
  *
  * @author Adrian Quintana (adrian.perez@ucl.ac.uk)
- * @author Boris Marin 
+ * @author borismarin
  */
 
 define(function(require) {
@@ -74,6 +74,7 @@ define(function(require) {
 					this.force.size([width, height]).resume();
 				}
 				else if (this.options.connectivityLayout == 'matrix') {
+					$('#' + this.id + '-ordering').remove();
 					this.createLayout();
 				}
 			}
@@ -144,12 +145,11 @@ define(function(require) {
             this.options.innerHeight = this.connectivityContainer.innerHeight() - this.widgetMargin;
             
             this.svg = d3.select("#"+this.id)
-                            .append("svg")
+                          .append("svg")
                             .attr("width", this.options.innerWidth)
                             .attr("height", this.options.innerHeight);
             
             if (this.options.connectivityLayout == 'matrix'){
-                $('#' + this.id + '-filters').remove();
                 this.createMatrixLayout();
             }
             else if (this.options.connectivityLayout == 'force') {
@@ -221,6 +221,159 @@ define(function(require) {
         },
 
 
+        createMatrixLayout: function(){
+
+            var margin = {top: 30, right: 10, bottom: 10, left: 3};
+            var legendWidth = 120;
+
+            var matrixDim = (this.options.innerHeight < (this.options.innerWidth - legendWidth))?(this.options.innerHeight):(this.options.innerWidth - legendWidth);
+            
+            var x = d3.scale.ordinal().rangeBands([0, matrixDim - margin.top]),
+            // Opacity
+            z = d3.scale.linear().domain([0, 4]).clamp(true),
+            // Colors
+            c = d3.scale.category10();
+            
+            this.svg
+                .style("padding-left", margin.left + "px")
+                .style("padding-top", margin.top + "px")
+                .append("g")
+                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+            var matrix = [];
+            var nodes = this.dataset.nodes;
+            var root=this.dataset.root;
+            var n = nodes.length;
+
+            // Compute index per node.
+            nodes.forEach(function(node, i) {
+                node.pre_count = 0;
+                node.post_count = 0;
+                matrix[i] = d3.range(n).map(function(j) { return {x: j, y: i, z: 0}; });
+            });
+            
+            // Convert links to matrix; count pre / post conns.
+            this.dataset.links.forEach(function(link) {
+                matrix[link.source][link.target].z = link.weight ? link.linkType : 0;
+                nodes[link.source].pre_count += 1;
+                nodes[link.target].post_count += 1;
+            });
+
+            //Sorting matrix entries.
+            //TODO: runtime specified sorting criteria
+        	var sortOptions = {
+        			'id' : 'By entity name',
+        			'pre_count' : 'By # pre',
+        			'post_count' : 'By # post'
+        	};
+            //  Precompute the orders.
+            var orders = {
+                id: d3.range(n).sort(function(a, b) { return d3.ascending(nodes[a].id, nodes[b].id); }),
+                pre_count: d3.range(n).sort(function(a, b) { return nodes[b].pre_count - nodes[a].pre_count; }),
+                post_count: d3.range(n).sort(function(a, b) { return nodes[b].post_count - nodes[a].post_count; }),
+                //community: d3.range(n).sort(function(a, b) { return nodes[b].community - nodes[a].community; }),
+            };
+            // Default sort order.
+            x.domain(orders.id);
+            
+            var rect = this.svg
+                          .append("rect")
+                            .attr("class", "background")
+                            .attr("width", matrixDim - margin.left)
+                            .attr("height", matrixDim - margin.top);
+
+            var row = this.svg.selectAll(".row")
+                  .data(matrix)
+                .enter().append("g")
+                  .attr("class", "row")
+                  .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
+                  .each(row);
+
+            row.append("line")
+                  .attr("x2", this.options.innerWidth);
+
+            var column = this.svg.selectAll(".column")
+                  .data(matrix)
+                .enter().append("g")
+                  .attr("class", "column")
+                  .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
+
+            column.append("line")
+                    .attr("x1", -this.options.innerWidth);
+              
+            var tooltip = this.svg
+                .append("text")
+                  .attr("x", 0)
+                  .attr("y", -10)
+                  .attr('class', 'connectionlabel')
+                  .text("Hover the squares to see the connections.");
+            
+           this.createLegend('legend', c, {x: matrixDim, y:0});
+            
+           //Sorting matrix entries by criteria specified via combobox 
+		    var orderContainer = $('<div/>', {
+		    	id: this.id + '-ordering',
+		    	style: 'width:' + legendWidth + 'px;left:' + (matrixDim + this.widgetMargin) + 'px;top:' + (matrixDim - 32) + 'px;',
+		    	class: 'connectivity-ordering'
+		    }).appendTo(this.connectivityContainer);
+		    
+		    var orderCombo = $('<select/>');
+		    $.each(sortOptions, function(k, v) {
+		        $('<option/>', {value: k, text: v}).appendTo(orderCombo);
+		    });
+		    orderContainer.append($('<span/>', {class: 'connectivity-ordering-label', text: 'Order by:'}).append(orderCombo))
+               
+            orderCombo.on("change", function(svg) {
+                return function() {
+                    x.domain(orders[this.value]);
+            
+                    var t = svg.transition().duration(2500);
+                    t.selectAll(".row")
+                        .delay(function(d, i) { return x(i) * 4; })
+                        .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
+                        .selectAll(".cell")
+                        .delay(function(d) { return x(d.x) * 4; })
+                        .attr("x", function(d) { return x(d.x); });
+            
+                    t.selectAll(".column")
+                        .delay(function(d, i) { return x(i) * 4; })
+                        .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
+                }
+            }(this.svg));
+            
+            // Draw squares for each connection
+            function row(row) {
+                var cell = d3.select(this).selectAll(".cell")
+                    .data(row.filter(function(d) { return d.z;})) //only paint conns
+                  .enter().append("rect")
+                    .attr("class", "cell")
+                    .attr("x", function(d) { return x(d.x); })
+                    .attr("width", x.rangeBand())
+                    .attr("height", x.rangeBand())
+                    .attr("title", function(d) { return d.id;})
+                    .style("fill-opacity", function(d) { return z(d.z); })
+                    .style("fill", function(d) {return c(d.z); })
+                    .on("click", function(d){
+                        Simulation.unSelectAll();
+                        //Ideally instead of hiding the connectivity lines we'd show only the ones connecting the two cells, also we could higlight the connection.
+                        eval(root.name+"."+nodes[d.x].id).select();
+                        eval(root.name+"."+nodes[d.x].id).showConnectionLines(false);
+                        eval(root.name+"."+nodes[d.y].id).select();
+                        eval(root.name+"."+nodes[d.y].id).showConnectionLines(false);
+                        })
+                    .on("mouseover", function(d){
+                        d3.select(this.parentNode.appendChild(this)).transition().duration(100).style({'stroke-opacity':1,'stroke':'white', 'stroke-width':'2'});
+                        d3.select("body").style('cursor','pointer');
+                        return tooltip.transition().duration(100).text(nodes[d.x].id + " is connected to " + nodes[d.y].id);
+                        })
+                    .on("mouseout", function(){
+                        d3.select(this).transition().duration(100).style({'stroke-opacity':0,'stroke':'white'});
+                        d3.select("body").style('cursor','default');
+                        return tooltip.text("");
+                        });
+            }
+        },
+
+
         createLegend: function(id, colorScale, position, title){
 
         	//TODO: boxes should scale based on number of items 
@@ -267,174 +420,6 @@ define(function(require) {
         	
         },
 
-
-        createMatrixLayout: function(){
-
-            var margin = {top: 30, right: 10, bottom: 10, left: 3};
-
-            var legendWidth = 120;
-
-            var matrixDim = (this.options.innerHeight < (this.options.innerWidth - legendWidth))?(this.options.innerHeight):(this.options.innerWidth - legendWidth);
-            
-            var x = d3.scale.ordinal().rangeBands([0, matrixDim - margin.top]),
-            // Opacity
-            z = d3.scale.linear().domain([0, 4]).clamp(true),
-            // Colors
-            c = d3.scale.category10();
-            
-            this.svg
-                .style("padding-left", margin.left + "px")
-                .style("padding-top", margin.top + "px")
-                .append("g")
-                .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
-            var matrix = [];
-            var nodes = this.dataset.nodes;
-            var root=this.dataset.root;
-            var n = nodes.length;
-
-            // Compute index per node.
-            nodes.forEach(function(node, i) {
-                node.pre_count = 0;
-                node.post_count = 0;
-                matrix[i] = d3.range(n).map(function(j) { return {x: j, y: i, z: 0}; });
-            });
-            
-            // Convert links to matrix; count pre / post conns.
-            this.dataset.links.forEach(function(link) {
-                matrix[link.source][link.target].z = link.weight ? link.linkType : 0;
-                nodes[link.source].pre_count += 1;
-                nodes[link.target].post_count += 1;
-            });
-
-            // Precompute the orders.
-            var orders = {
-                id: d3.range(n).sort(function(a, b) { return d3.ascending(nodes[a].id, nodes[b].id); }),
-                //community: d3.range(n).sort(function(a, b) { return nodes[b].community - nodes[a].community; }),
-                pre_count: d3.range(n).sort(function(a, b) { return nodes[b].pre_count - nodes[a].pre_count; }),
-                post_count: d3.range(n).sort(function(a, b) { return nodes[b].post_count - nodes[a].post_count; }),
-            };
-            
-//          TODO: Commented it out until we have Louvain Community detection was implemented
-//          var colours = {
-//                  id: function(d) {return c(d.z);},
-//                  community: function(d) {return nodes[d.x].community == nodes[d.y].community ? c(nodes[d.x].community) : null;},
-//          };
-
-            // The default sort order.
-            x.domain(orders.id);
-            
-            var rect = this.svg
-                          .append("rect")
-                            .attr("class", "background")
-                            .attr("width", matrixDim - margin.left)
-                            .attr("height", matrixDim - margin.top);
-
-                
-            var row = this.svg.selectAll(".row")
-                  .data(matrix)
-                .enter().append("g")
-                  .attr("class", "row")
-                  .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
-                  .each(row);
-
-            row.append("line")
-                  .attr("x2", this.options.innerWidth);
-
-            var column = this.svg.selectAll(".column")
-                  .data(matrix)
-                .enter().append("g")
-                  .attr("class", "column")
-                  .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
-
-            column.append("line")
-                    .attr("x1", -this.options.innerWidth);
-              
-            var tooltip = this.svg
-                .append("text")
-                  .attr("x", 0)
-                  .attr("y", -10)
-                  .attr('class', 'connectionlabel')
-                  .text("Hover the squares to see the connections.");
-            
-           this.createLegend('legend', c, {x: matrixDim, y:0});
-            
-            //FILTERS AND EVENTS
-		    //this.connectivityContainer.append("<div id='filters' style='width:" + legendWidth + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");
-		    var orderContainer = $('<div/>', {
-		    	id: this.id + '-ordering',
-		    	style: 'width:' + legendWidth + 'px;left:' + (matrixDim + this.widgetMargin) + 'px;top:' + (matrixDim - 32) + 'px;',
-		    	class: 'connectivity-ordering'
-		    }).appendTo(this.connectivityContainer);
-		    
-		    var orderCombo = $('<select/>');
-		    var sortOptions = {'id': 'By entity name',
-		    				'pre_count': 'By # pre',
-		    				'post_count': 'By # post'};
-		    $.each(sortOptions, function(k, v) {
-		        $('<option/>', {value: k, text: v}).appendTo(orderCombo);
-		    });
-		    orderContainer.append($('<span/>', {class: 'connectivity-ordering-label', text: 'Order by:'}).append(orderCombo))
-               
-            orderCombo.on("change", function(svg) {
-                return function() {
-                    x.domain(orders[this.value]);
-            
-                    var t = svg.transition().duration(2500);
-                    t.selectAll(".row")
-                        .delay(function(d, i) { return x(i) * 4; })
-                        .attr("transform", function(d, i) { return "translate(0," + x(i) + ")"; })
-                        .selectAll(".cell")
-                        .delay(function(d) { return x(d.x) * 4; })
-                        .attr("x", function(d) { return x(d.x); });
-            
-                    t.selectAll(".column")
-                        .delay(function(d, i) { return x(i) * 4; })
-                        .attr("transform", function(d, i) { return "translate(" + x(i) + ")rotate(-90)"; });
-                }
-            }(this.svg));
-            
-            // UTILITIES
-            function row(row) {
-                var cell = d3.select(this).selectAll(".cell")
-                    .data(row.filter(function(d) { return d.z;})) //only paint conns
-                    .enter().append("rect")
-                    .attr("class", "cell")
-                    .attr("x", function(d) { return x(d.x); })
-                    .attr("width", x.rangeBand())
-                    .attr("height", x.rangeBand())
-                    .attr("title", function(d) { return d.id;})
-                    .style("fill-opacity", function(d) { return z(d.z); })
-                    .style("fill", function(d) {return c(d.z); })
-                    .on("click", function(d){
-                        Simulation.unSelectAll();
-                        //Ideally instead of hiding the connectivity lines we'd show only the ones connecting the two cells, also we could higlight the connection.
-                        eval(root.name+"."+nodes[d.x].id).select();
-                        eval(root.name+"."+nodes[d.x].id).showConnectionLines(false);
-                        eval(root.name+"."+nodes[d.y].id).select();
-                        eval(root.name+"."+nodes[d.y].id).showConnectionLines(false);
-                        })
-                    .on("mouseover", function(d){
-                        d3.select(this.parentNode.appendChild(this)).transition().duration(100).style({'stroke-opacity':1,'stroke':'white', 'stroke-width':'2'});
-                        d3.select("body").style('cursor','pointer');
-                        return tooltip.transition().duration(100).text(nodes[d.x].id + " is connected to " + nodes[d.y].id);
-                        })
-                    .on("mouseout", function(){
-                        d3.select(this).transition().duration(100).style({'stroke-opacity':0,'stroke':'white'});
-                        d3.select("body").style('cursor','default');
-                        return tooltip.text("");
-                        });
-            }
-            
-            
-            function mouseover(p) {
-                d3.selectAll(".row text").classed("active", function(d, i) { return i == p.y; });
-                d3.selectAll(".column text").classed("active", function(d, i) { return i == p.x; });
-            }
-            
-            function mouseout() {
-                d3.selectAll("text").classed("active", false);
-            }
-        },
         
         createNode: function(nodeId) {
             if (!(nodeId in this.mapping)){

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -149,7 +149,7 @@ define(function(require) {
                             .attr("height", this.options.innerHeight);
             
             if (this.options.connectivityLayout == 'matrix'){
-                $("#filters").remove();
+                $('#' + this.id + '-filters').remove();
                 this.createMatrixLayout();
             }
             else if (this.options.connectivityLayout == 'force') {
@@ -359,10 +359,23 @@ define(function(require) {
            this.createLegend('legend', c, {x: matrixDim, y:0});
             
             //FILTERS AND EVENTS
-		    this.connectivityContainer.append("<div id='filters' style='width:" + legendWidth + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");
-		    $('#filters').append("<span class='filtersLabel'>Select the ordering</span><select id='order'><option value='id'>by Entity Name</option><option value='pre_count'>by # pre</option><option value='post_count'>by # post</option></select>");
+		    //this.connectivityContainer.append("<div id='filters' style='width:" + legendWidth + "px;left:" + (matrixDim + this.widgetMargin) + "px;top:" + (matrixDim - 32) + "px;'></div>");
+		    var orderContainer = $('<div/>', {
+		    	id: this.id + '-ordering',
+		    	style: 'width:' + legendWidth + 'px;left:' + (matrixDim + this.widgetMargin) + 'px;top:' + (matrixDim - 32) + 'px;',
+		    	class: 'connectivity-ordering'
+		    }).appendTo(this.connectivityContainer);
+		    
+		    var orderCombo = $('<select/>');
+		    var sortOptions = {'id': 'By entity name',
+		    				'pre_count': 'By # pre',
+		    				'post_count': 'By # post'};
+		    $.each(sortOptions, function(k, v) {
+		        $('<option/>', {value: k, text: v}).appendTo(orderCombo);
+		    });
+		    orderContainer.append($('<span/>', {class: 'connectivity-ordering-label', text: 'Order by:'}).append(orderCombo))
                
-            d3.select('#order').on("change", function(svg) {
+            orderCombo.on("change", function(svg) {
                 return function() {
                     x.domain(orders[this.value]);
             

--- a/src/main/webapp/js/widgets/connectivity/Connectivity.js
+++ b/src/main/webapp/js/widgets/connectivity/Connectivity.js
@@ -120,28 +120,8 @@ define(function(require) {
 							this.createNode(sourceId, conn2nodeType(source));
 							this.createNode(targetId, conn2nodeType(target));
                             
-							var linkItem = {};
-							linkItem["source"] = this.mapping[sourceId];
-							linkItem["target"] = this.mapping[targetId];
-                            
-                           linkItem["type"] = conn2linkType(connectionItem);
-                           linkItem["weight"] = conn2linkWeight(connectionItem);
+                            this.createLink(sourceId, targetId, conn2linkType(connectionItem), conn2linkWeight(connectionItem));
                         	    
-//							var customNodes = connectionItem.getCustomNodes();
-//							for (var customNodeIndex in connectionItem.getCustomNodes()){
-//								if ('getChildren' in customNodes[customNodeIndex]){
-//									var customNodesChildren = customNodes[customNodeIndex].getChildren();
-//									for (var customNodeChildIndex in customNodesChildren){
-//										if (customNodesChildren[customNodeChildIndex].getId() == "Id"){
-//											linkItem["type"] = customNodesChildren[customNodeChildIndex].getValue();
-//                                    	}
-//										else if (customNodesChildren[customNodeChildIndex].getId() == "GBase"){
-//											linkItem["weight"] = customNodesChildren[customNodeChildIndex].getValue();
-//										}
-//									}
-//								}
-//							}
-							this.dataset["links"].push(linkItem);
 						}
 					}
 				}
@@ -219,7 +199,6 @@ define(function(require) {
             });
             
             var legendPosition = {x:  0.7 * this.options.innerWidth, y: 0};
-
 
             //Nodes
             var legendBottom = this.createLegend('legend', nodeTypeScale, legendPosition, 'Nodes - Cell Types');
@@ -432,16 +411,27 @@ define(function(require) {
         },
 
         
-        createNode: function(nodeId, nodeType) {
-            if (!(nodeId in this.mapping)){
-                var nodeItem = {};
-                nodeItem["id"] = nodeId;
-                nodeItem["type"] = nodeType;
+        createNode: function(id, type) {
+            if (!(id in this.mapping)){
+                var nodeItem = {
+                	id: id,
+                	type: type
+                };
                 this.dataset["nodes"].push(nodeItem);
                 
                 this.mapping[nodeItem["id"]] = this.mappingSize;
                 this.mappingSize++;
             }
+        },
+
+        createLink: function(sourceId, targetId, type, weight) {
+                var linkItem = {
+                	source: this.mapping[sourceId],
+					target: this.mapping[targetId],
+                	type:  type,
+                	weight: weight
+                };
+                this.dataset["links"].push(linkItem);
         },
         
         /**


### PR DESCRIPTION
- fixed opening multiple widgets simultaneously
- fixed sorting for multiple conn matrices
- fixed a lot of other things I don't remember anymore
- most important: no more domain hardcoded properties (line widths / colours / node colours can be mapped to anything) - all done through {options}. 
- Examples using the conn widget will have to be updated.