### PR TITLE
Added json as an available output format for logout webservice

### DIFF
--- a/src/main/java/org/geppetto/frontend/controllers/Login.java
+++ b/src/main/java/org/geppetto/frontend/controllers/Login.java
@@ -96,7 +96,7 @@ public class Login
 	}
 
 	@RequestMapping(value = "/logout", method = RequestMethod.GET)
-	public String logout()
+	public String logout(@RequestParam(defaultValue="web",required=false) String outputFormat, HttpServletResponse response) throws IOException
 	{
 		IGeppettoDataManager dataManager = DataManagerHelper.getDataManager();
 		if(!dataManager.isDefault())
@@ -115,7 +115,10 @@ public class Login
 				}
 			}
 		}
-		return "redirect:/";
+		if (outputFormat.equals("web"))
+			response.sendRedirect("/");
+		return null;
+		
 	}
 
 }


### PR DESCRIPTION
@tarelli Redirection response for webservice calls using CORS are not allowed for Safari. This causes OSB not to work properly in Safari. I have added a new parameter that can be used to define which type of answer you are expecting from the webservice. If this parameter is not passed the logout webservice works as usual.