### PR TITLE
Fix Close Project Exception

### DIFF
--- a/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
+++ b/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
@@ -498,11 +498,6 @@ public class ConnectionHandler
 		}
 	}
 
-	public void userBecameIdle(String requestID)
-	{
-		closeProject();
-	}
-
 	/**
 	 * @param requestID
 	 * @param modelPath

--- a/src/main/java/org/geppetto/frontend/controllers/WebsocketConnection.java
+++ b/src/main/java/org/geppetto/frontend/controllers/WebsocketConnection.java
@@ -317,11 +317,6 @@ public class WebsocketConnection extends MessageInbound implements MessageSender
 
 				break;
 			}
-			case IDLE_USER:
-			{
-				connectionHandler.userBecameIdle(requestID);
-				break;
-			}
 			case GET_SUPPORTED_OUTPUTS:
 			{
 				parameters = new Gson().fromJson(gmsg.data, new TypeToken<HashMap<String, String>>()

--- a/src/main/java/org/geppetto/frontend/messages/InboundMessages.java
+++ b/src/main/java/org/geppetto/frontend/messages/InboundMessages.java
@@ -53,7 +53,6 @@ public enum InboundMessages {
 	GET_WATCH("get_watch"),
 	CLEAR_WATCHED_VARIABLES("clear_watch"),
 	NOTIFY_USER("notify_user"),
-	IDLE_USER("idle_user"),
 	GET_MODEL_TREE("get_model_tree"),
 	GET_SIMULATION_TREE("get_simulation_tree"),
 	GET_SUPPORTED_OUTPUTS("get_supported_outputs"),

--- a/src/main/webapp/js/GEPPETTO.Main.js
+++ b/src/main/webapp/js/GEPPETTO.Main.js
@@ -148,8 +148,8 @@ define(function (require) {
                             GEPPETTO.Main.idleTime = 0;
                             GEPPETTO.Main.disconnected = true;
                             GEPPETTO.FE.disableSimulationControls();
-                            GEPPETTO.MessageSocket.send("idle_user", null);
-
+                            GEPPETTO.MessageSocket.close();
+                            
                             var webGLStarted = GEPPETTO.init(GEPPETTO.FE.createContainer());
                             var webWorkersSupported = (typeof(Worker) !== "undefined") ? true : false;
 


### PR DESCRIPTION
We were having an exception in Geppetto from time to time because we try to close a project server side but actually the project was already closed. Many wise men from all around the world have tried to find an answer for this phenomenon. Finally, the mystery has been disclosed: we close the project when there is a prolonged inactivity and we close it again when the user leave the page, close the tab, the browser, etc... The first one is done on purpose but the second one is an event automatically triggered because of the socket disconnection. When the code in charged of dealing with the second event tries to remove the project from the project list server side and exception was raised as the project couldn't be found server side.

The solution implemented is to actually not only close the project when there is a prolonged inactivity but to close the socket. Therefore, if the user leaves the page (close the tab, browser, etc) no further event will be triggered and the world will be a better place. 

@tarelli I have removed the idle_user call as I think it is better to just close the socket . This call will actually close the socket and the project.