### PR TITLE
trying to get the travis script to run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 before_script:
 - npm install -g bower
 install:
-- travis-install.sh
+- ./travis-install.sh
 env:
   global:
     secure: EvqtUrZj3GsqzAkjZIVf2ZIze6ec72G8Dnkc0J3lKxwDTK6+KgIYgRWUWWO6tzL5Mn3Y+kkiHvyAkrHNPb2QZVBAdOdE3O308WRi64FF71nurd46zE43K/sSxcX/zCoBtxsz49oRcluPWl+nGDi/iKEysgcnQCvz23VWEYHAsOk=


### PR DESCRIPTION
@tarelli this seems to solve it.  [Now the failure](https://travis-ci.org/openworm/org.geppetto.frontend/builds/148927932) is not about the travis-install.sh script being missing but something else.  Unclear why it was working fine before and now it stopped working with no changes.  Maybe something subtle on travis' backend??  

(PR to the wrong branch last time)