### PR TITLE
change docs build from install to site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -439,7 +439,7 @@
 				</configuration>
 				<executions>
 					<execution>
-						<phase>install</phase>
+						<phase>site</phase>
 						<goals>
 							<goal>jsdoc3</goal>
 						</goals>


### PR DESCRIPTION
use `mvn site` to get the jsdocs built now.  speeds up regular builds