### PR TITLE
add write permissions check

### DIFF
--- a/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
+++ b/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
@@ -1428,9 +1428,6 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 	 * 
 	 * @param requestID
 	 */
-	/**
-	 * @param requestID
-	 */
 	public void checkUserPrivileges(String requestID)
 	{
 		boolean hasPersistence = false;

--- a/src/main/webapp/js/geppettoProject/ExperimentsController.js
+++ b/src/main/webapp/js/geppettoProject/ExperimentsController.js
@@ -198,7 +198,7 @@ define(function (require) {
                     setView = true;
                 }
                 
-                if(setView && GEPPETTO.UserController.persistence){
+                if(setView && GEPPETTO.UserController.persistence && GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT)){
                     var parameters = {};
                     var experimentId = activeExperiment ? Project.getActiveExperiment().getId() : -1;
                     parameters["experimentId"] = experimentId;

--- a/src/main/webapp/js/geppettoProject/ExperimentsController.js
+++ b/src/main/webapp/js/geppettoProject/ExperimentsController.js
@@ -198,7 +198,7 @@ define(function (require) {
                     setView = true;
                 }
                 
-                if(setView && GEPPETTO.UserController.persistence && GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT)){
+                if(setView && GEPPETTO.UserController.hasPermission(GEPPETTO.Resources.WRITE_PROJECT)){
                     var parameters = {};
                     var experimentId = activeExperiment ? Project.getActiveExperiment().getId() : -1;
                     parameters["experimentId"] = experimentId;


### PR DESCRIPTION
see also: https://github.com/openworm/org.geppetto.simulation/pull/131
this fixes issue with OSB sample projects having their experiment state written (since they are persisted, see comodl because osb.org has a temporary fix in place; for example every time you open HH there are more popups because the script runs, and the ones from before have been saved)

- [ ] Run [CoreTests.js Casper Tests](https://github.com/openworm/org.geppetto.frontend/blob/master/src/main/webapp/js/pages/tests/casperjs/README.md), make sure they all pass, attach screenshot
- [ ] Run [UITests.js Casper Tests](https://github.com/openworm/org.geppetto.frontend/blob/master/src/main/webapp/js/pages/tests/casperjs/README.md), make sure they all pass, attach screenshot
- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
