### PR TITLE
Carousel Fixes

### DIFF
--- a/src/main/webapp/js/components/interface/carousel/Carousel.js
+++ b/src/main/webapp/js/components/interface/carousel/Carousel.js
@@ -12,16 +12,19 @@ define(function (require) {
 			var settings = {
 				infinite: true,
 				speed: 500,
-				slidesToShow: 1,
-				slidesToScroll: 1
+				slidesToShow: 1
 			};
 
 			this.state = {
-				settings: $.extend(settings, this.props.settings),
-				files: this.props.files
+				settings: $.extend(settings, props.settings),
+				files: props.files
 			};
 
 			this.download = this.download.bind(this);
+		}
+
+		componentDidMount(){
+			this.refs.slider.forceUpdate();
 		}
 
 		setData(files) {
@@ -39,7 +42,7 @@ define(function (require) {
 
 			if (this.state.files != undefined) {
 				return (
-					<Slider {...this.state.settings}>
+					<Slider {...this.state.settings} ref='slider'>
 						{items}
 					</Slider>
 				)


### PR DESCRIPTION
- Minor fix on constructor so settings are properly passed.
- Fix for the carousel to display properly. Carousel layout was not looking properly on init because it was calculated based on the initial parent container. As we are manipulating the dom from different sides it was not properly recalculated. A forceupdate on componentdidmount makes the trick. Now it works properly when it is a regular component or a component inside a jquery dialog.
