### PR TITLE
fix run bug when setting params from exp table

### DIFF
--- a/src/main/webapp/js/geppettoProject/model/SimulatorConfiguration.js
+++ b/src/main/webapp/js/geppettoProject/model/SimulatorConfiguration.js
@@ -142,6 +142,8 @@ define(function (require) {
          */
         setTimeStep: function (timeStep) {
             var properties = {};
+            if (typeof timeStep === 'string')
+                timeStep = parseFloat(timestep);
             properties["timeStep"] = timeStep;
             properties["aspectInstancePath"] = this.aspectInstancePath;
             this.getParent().saveExperimentProperties(properties);
@@ -165,6 +167,8 @@ define(function (require) {
          */
         setLength: function (length) {
             var properties = {};
+            if (typeof length === 'string')
+                length = parseFloat(length);
             properties["length"] = length;
             properties["aspectInstancePath"] = this.aspectInstancePath;
             this.getParent().saveExperimentProperties(properties);


### PR DESCRIPTION
if timestep or length params modified in exp table then the expt run form won't validate as they become set as strings rather than floats

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
