### PR TITLE
fix/pop_spatial_distribution: state transition handled in the Adapter…

### DIFF
--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -165,7 +165,6 @@ define(function (require) {
                     if (event != null && event.target.value != undefined) {
                         targetValue = event.target.value;
                     }
-                    this.setState({ value: targetValue });
                     var v = value
                     this.triggerUpdate(function () {
                         // For textfields value is retrived from the event. For dropdown value is retrieved from the value


### PR DESCRIPTION
- Fixed the state transition, not happening anymore when both the values are setted in the PythonControlledCapability component but handled singularly in the AdapterComponent.