### PR TITLE
fix/799: aspectConfiguration additional check in case not defined in …

### DIFF
--- a/src/main/webapp/js/geppettoProject/ProjectsController.js
+++ b/src/main/webapp/js/geppettoProject/ProjectsController.js
@@ -84,7 +84,7 @@ define(function (require) {
                         dataType == GEPPETTO.Resources.STATE_VARIABLE && experiments[j].status == GEPPETTO.Resources.ExperimentStatus.COMPLETED
                         || dataType == GEPPETTO.Resources.PARAMETER
                     ){
-                        if (experiments[j].aspectConfigurations[0] != undefined) {
+                        if (experiments[j].aspectConfigurations != null ? (experiments[j].aspectConfigurations[0] != undefined ? true : false) : false) {
                             dataSource = (dataType == GEPPETTO.Resources.STATE_VARIABLE) ?
                                 experiments[j].aspectConfigurations[0].watchedVariables :
                                 experiments[j].aspectConfigurations[0].modelParameter;


### PR DESCRIPTION
- Casper tests fixed due to missing check if aspectConfiguration was not defined in the experiment's json.
- Additional check added.