### PR TITLE
fix unit throw exception error

### DIFF
--- a/src/main/webapp/js/components/widgets/plot/Plot.js
+++ b/src/main/webapp/js/components/widgets/plot/Plot.js
@@ -831,8 +831,9 @@ define(function (require) {
                     try {
                         var labelY = this.inhomogeneousUnits ? "SI Units" : this.getUnitLabel(unit);
                     }catch (e) {
-						labelY = ""
-                    }try {
+                        labelY = ""
+                    }
+                    try {
                         var labelX = this.getUnitLabel(this.xVariable.getUnit());
                     }catch (e) {
                         labelX = ""

--- a/src/main/webapp/js/components/widgets/plot/Plot.js
+++ b/src/main/webapp/js/components/widgets/plot/Plot.js
@@ -821,27 +821,34 @@ define(function (require) {
 			}
 		},
 
-		/*
-		 * Retrieves X and Y axis labels from the variables being plotted
-		 */
-		updateAxis: function (key) {
-			if (!this.labelsUpdated) {
-				var unit = this.variables[this.getLegendInstancePath(key)].getUnit();
-				if (unit != null) {
-					var labelY = this.inhomogeneousUnits ? "SI Units" : this.getUnitLabel(unit);
-					var labelX = this.getUnitLabel(this.xVariable.getUnit());
-					this.labelsUpdated = true;
-					this.plotOptions.yaxis.title = labelY;
-					this.plotOptions.xaxis.title = labelX;
+        /*
+         * Retrieves X and Y axis labels from the variables being plotted
+         */
+        updateAxis: function (key) {
+            if (!this.labelsUpdated) {
+                var unit = this.variables[this.getLegendInstancePath(key)].getUnit();
+                if (unit != null) {
+                    try {
+                        var labelY = this.inhomogeneousUnits ? "SI Units" : this.getUnitLabel(unit);
+                    }catch (e) {
+						labelY = ""
+                    }try {
+                        var labelX = this.getUnitLabel(this.xVariable.getUnit());
+                    }catch (e) {
+                        labelX = ""
+                    }
+                    this.labelsUpdated = true;
+                    this.plotOptions.yaxis.title = labelY;
+                    this.plotOptions.xaxis.title = labelX;
 
-					if(labelY == null || labelY == ""){
-						this.plotOptions.margin.l = 30;
-					}
-					//update the axia labels for the plot
-					Plotly.relayout(this.plotDiv, this.plotOptions);
-				}
-			}
-		},
+                    if(labelY == null || labelY == ""){
+                        this.plotOptions.margin.l = 30;
+                    }
+                    //update the axia labels for the plot
+                    Plotly.relayout(this.plotDiv, this.plotOptions);
+                }
+            }
+        },
 
 		/**
 		 * Utility function to get unit label given raw unit symbol string


### PR DESCRIPTION
Unit throws `SyntaxError: Unit "UnitValue" not found`. when SI Unit is not found.
This pull request will catch this excpetion and save unit as an empty string.