### PR TITLE
Plot LFP

### DIFF
--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -318,11 +318,29 @@ define(function (require) {
                 }
 
                 callPythonMethod = (value) => {
-                    Utils.sendPythonMessage(this.props.method, []).then((response) => {
-                        if (Object.keys(response).length != 0) {
-                            this.setState({ pythonData: response });
-                        }
-                    });
+                    if (this.props.method != undefined && this.props.method!='') {
+                      Utils.sendPythonMessage(this.props.method, []).then((response) => {
+                          if (Object.keys(response).length != 0) {
+                              this.setState({ pythonData: response });
+                          }
+                      })
+                    }
+                    else {
+                      this.triggerUpdate(() => {
+                        var options = this.props.children.map((child) => {
+                          return child.key;
+                        })
+                        this.setState({pythonData: options})
+                      })
+                    }
+                }
+                
+                triggerUpdate(updateMethod) {
+                    //common strategy when triggering processing of a value change, delay it, every time there is a change we reset
+                    if (this.updateTimer != undefined) {
+                        clearTimeout(this.updateTimer);
+                    }
+                    this.updateTimer = setTimeout(updateMethod, 500);
                 }
 
                 componentDidUpdate(prevProps, prevState) {


### PR DESCRIPTION
requires: 
https://github.com/MetaCell/geppetto-netpyne/pull/39
https://github.com/MetaCell/NetPyNE-UI/pull/40
https://github.com/Neurosim-lab/netpyne/pull/328

**PythonControlledControlWithPythonDataFetch** requires a prop **method**.

With this change, if there is no prop **method** , the component retrieves the options from metadata in NetPyNE.

This problem arrived when I was trying to set multiple options for a select field in Plot LFP. The options are fixed ["PSD", "spectrogram", "locations", "timeSeries"], so I don't need to call a method to find out which options are available, but I do need to keep record of which ones the user already selected.