### PR TITLE
fix type format error

### DIFF
--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -210,6 +210,7 @@ define(function (require) {
                     delete wrappedComponentProps.dimensionType;
                     delete wrappedComponentProps.noStyle;
                     delete wrappedComponentProps.validate;
+                    delete wrappedComponentProps.prePythonSyncProcessing;
 
                     if (wrappedComponentProps.realType == 'func' || wrappedComponentProps.realType == 'float') {
                         wrappedComponentProps['errorText'] = this.state.errorMsg;
@@ -362,6 +363,8 @@ define(function (require) {
                     delete wrappedComponentProps.model;
                     delete wrappedComponentProps.postProcessItems;
                     delete wrappedComponentProps.validate;
+                    delete wrappedComponentProps.prePythonSyncProcessing;
+                    
                     if (this.props.postProcessItems) {
                         var items = this.props.postProcessItems(this.state.pythonData, this.state.value);
                     }


### PR DESCRIPTION
this will be needed for CNS. Basically it deals with: 

- float fields been filled up with text,
- fields that end up with a value equal to an empty string,
- fields that must contain a default value for netpyne to work.

**PythonControlledCapability.js** should not contain things like this one: 

` Utils.execPythonCommand('del netpyne_geppetto.' + this.props.model)`

but we need to rethink how to deal with error messages and fields completed with the wrong type. I am opening a Trello Card for this topic.

### To test this PR: 

- try to enter a string in a textfield (an alert will appear)
- fill a field with some value and then check with `print(netpyne_geppetto.netParams.popParams['cellType'])`. the value that you entered. Then proceed to delete the field and type the previous command again. (the key should not appear anymore)
- go to configuration tab and try to delete the duration of the simulation (this field must contain a value in order for netpyne to simulate the network)
- Non of the values in `netpyne_geppetto.simConfig`, so this PR also take cares of that by checking if **this.props.model** contains the word **simConfig** (this rule does not apply for *simConfig.analysis* which could be deleted)

