### PR TITLE
Call parent if value changed

### DIFF
--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -134,7 +134,7 @@ define(function (require) {
 
                 updatePythonValue(newValue) {
                     if (this.props.prePythonSyncProcessing!==undefined) {
-                       newValue = this.props.prePythonSyncProcessing(newValue);
+                        newValue = this.props.prePythonSyncProcessing(newValue);
                     }
                     //whenever we invoke syncValueWithPython we will propagate the Javascript value of the model to Python
                     if (this.syncValueWithPython) {

--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -175,7 +175,7 @@ define(function (require) {
                         targetValue = event.target.value;
                     }
                     this.setState({ value: targetValue });
-                    
+
                     if (this.props.validate) {
                         this.props.validate(targetValue).then((errorState) => {
                             this.setState(errorState);

--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -175,6 +175,7 @@ define(function (require) {
                         targetValue = event.target.value;
                     }
                     this.setState({ value: targetValue });
+                    
                     if (this.props.validate) {
                         this.props.validate(targetValue).then((errorState) => {
                             this.setState(errorState);

--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -134,7 +134,7 @@ define(function (require) {
 
                 updatePythonValue(newValue) {
                     if (this.props.prePythonSyncProcessing!==undefined) {
-                      newValue = this.props.prePythonSyncProcessing(newValue);
+                       newValue = this.props.prePythonSyncProcessing(newValue);
                     }
                     //whenever we invoke syncValueWithPython we will propagate the Javascript value of the model to Python
                     if (this.syncValueWithPython) {
@@ -180,7 +180,7 @@ define(function (require) {
                             this.setState(errorState);
                         });
                     }
-                    
+
                     // For textfields value is retrieved from the event. For dropdown value is retrieved from the value
                     if (WrappedComponent.name!='SelectField') {
                       this.triggerUpdate(() => this.updatePythonValue(targetValue));

--- a/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
+++ b/src/main/webapp/js/communication/geppettoJupyter/PythonControlledCapability.js
@@ -134,7 +134,7 @@ define(function (require) {
 
                 updatePythonValue(newValue) {
                     if (this.props.prePythonSyncProcessing!==undefined) {
-                        newValue = this.props.prePythonSyncProcessing(newValue);
+                      newValue = this.props.prePythonSyncProcessing(newValue);
                     }
                     //whenever we invoke syncValueWithPython we will propagate the Javascript value of the model to Python
                     if (this.syncValueWithPython) {
@@ -175,15 +175,23 @@ define(function (require) {
                         targetValue = event.target.value;
                     }
                     this.setState({ value: targetValue });
-
                     if (this.props.validate) {
                         this.props.validate(targetValue).then((errorState) => {
                             this.setState(errorState);
                         });
                     }
-
+                    
                     // For textfields value is retrieved from the event. For dropdown value is retrieved from the value
-                    this.triggerUpdate(() => this.updatePythonValue(targetValue));
+                    if (WrappedComponent.name!='SelectField') {
+                      this.triggerUpdate(() => this.updatePythonValue(targetValue));
+                    }
+                    else {
+                      this.updatePythonValue(targetValue)
+                    }
+                    if (this.props.letParentKnowValueChanged!=undefined) {
+                      this.props.letParentKnowValueChanged(targetValue)
+                    }
+                    
                 }
 
                 // Autocomplete handle
@@ -212,7 +220,8 @@ define(function (require) {
                     delete wrappedComponentProps.noStyle;
                     delete wrappedComponentProps.validate;
                     delete wrappedComponentProps.prePythonSyncProcessing;
-
+                    delete wrappedComponentProps.letParentKnowValueChanged;
+                    
                     if (wrappedComponentProps.realType == 'func' || wrappedComponentProps.realType == 'float') {
                         wrappedComponentProps['errorText'] = this.state.errorMsg;
                     }


### PR DESCRIPTION
In some cases (such as SelectFields) it is useful to know when the value has changed (for instance, we would like to know if the user has selected a different **stimSource**)

Right know, if we have a **PythonControlledControl(SelectField)** it is impossible to know if the user has change the selected value in the SelectField. And we need to know what the user has selected because the next renders depend on that field. So far, we have managed to sort it out by writing a bunch of code every time we need to use a selectField (for instance by calling `Utils.SendPythonMessage` and `Utils.excePythonCommand`)

So, here we are adding a **prop*** called **letParentKnowValueChanged** that will let the parent to know if the child is changing the value of the SelectField. That will allow us to reRender the Parent if needed.

### To test:
https://github.com/MetaCell/geppetto-netpyne/pull/56 provides a more detailed explanation of this
