### PR TITLE
Fix/tabbed drawer netpyne ui

### DIFF
--- a/src/main/webapp/js/components/interface/console/console.less
+++ b/src/main/webapp/js/components/interface/console/console.less
@@ -1,5 +1,9 @@
 @import "./../../../../style/less/components/colors";
 
+#commandInputArea {
+    color: @primary_color;
+}
+
 .consoleContainer {
   height: 100%;
 }

--- a/src/main/webapp/js/components/interface/drawer/DrawerButton.js
+++ b/src/main/webapp/js/components/interface/drawer/DrawerButton.js
@@ -16,7 +16,8 @@ define(function (require) {
             super(props);
             this.state = {
                 mouseOver: false,
-                buttonActived: false}
+                buttonActived: false
+            }
 
             this.activeButton = this.activeButton.bind(this);
         }
@@ -25,18 +26,22 @@ define(function (require) {
         // the props labelKey is passed as parameter to the TabbedDrawer component to let it known
         // which button has been selected.
         activeButton() {
-            if((this.props.labelKey === this.props.selectedTab) && this.props.drawerOpened)
-                this.setState({buttonActived: true,
-                               mouseOver: false});
-            else 
-                this.setState({buttonActived: false,
-                               mouseOver: false});
+            if ((this.props.labelKey === this.props.selectedTab) && this.props.drawerOpened)
+                this.setState({
+                    buttonActived: true,
+                    mouseOver: false
+                });
+            else
+                this.setState({
+                    buttonActived: false,
+                    mouseOver: false
+                });
             this.props.functionDrawer(this.props.labelKey);
         }
 
         render() {
             var buttonStyle = "tabButton";
-            if(this.props.labelKey === this.props.selectedTab) {
+            if (this.props.labelKey === this.props.selectedTab) {
                 buttonStyle = " tabButton selectedTab";
             }
             return (

--- a/src/main/webapp/js/components/interface/drawer/TabbedDrawer.js
+++ b/src/main/webapp/js/components/interface/drawer/TabbedDrawer.js
@@ -180,5 +180,10 @@ define(function (require) {
             );
         }
     }
+    TabbedDrawer.defaultProps = {
+        childrenProp: [],
+        labels: [],
+        iconClass: []
+    };
     return TabbedDrawer;
 });

--- a/src/main/webapp/js/components/interface/drawer/TabbedDrawer.js
+++ b/src/main/webapp/js/components/interface/drawer/TabbedDrawer.js
@@ -15,7 +15,7 @@ define(function (require) {
     class TabbedDrawer extends React.Component {
         constructor(props) {
             super(props);
-            
+
             // the state drawerOpened is used to keep track of the display css attribute
             // the selectedTab tell us what child has to be displayed
             // the drawerHeight is used for the resizing
@@ -36,36 +36,36 @@ define(function (require) {
 
         // using the callback onResize of Rnd, keep tracks of the resize and animate the tabber
         drawerResizing(e) {
-            
-            if(e.clientY == e.layerY)
+
+            if (e.clientY == e.layerY)
                 var newOffset = window.innerHeight - e.clientY;
             else
                 var newOffset = window.innerHeight - (e.clientY - e.layerY);
 
-            if(newOffset >= window.innerHeight)
+            if (newOffset >= window.innerHeight)
                 newOffset = window.innerHeight - 50;
-            if(newOffset < 250)
+            if (newOffset < 250)
                 newOffset = 250;
-            this.setState({drawerHeight: newOffset});
-        }  
-        
+            this.setState({ drawerHeight: newOffset });
+        }
+
         // exact resize is calculated with the callback onResizeStop using also movementY
         drawerStopResizing(e) {
-            if(e.clientY == e.layerY)
+            if (e.clientY == e.layerY)
                 var newOffset = window.innerHeight - e.clientY;
             else
                 var newOffset = window.innerHeight - (e.clientY - e.layerY);
 
-            if(newOffset >= window.innerHeight)
+            if (newOffset >= window.innerHeight)
                 newOffset = window.innerHeight - 50;
-            if(newOffset < 250)
+            if (newOffset < 250)
                 newOffset = 250;
-            this.setState({drawerHeight: newOffset});
-        }  
+            this.setState({ drawerHeight: newOffset });
+        }
 
         // function to render all the buttons
         renderMyLabels() {
-            var renderedLabels = this.props.labels.map(function(label, index) {
+            var renderedLabels = this.props.labels.map(function (label, index) {
                 return (
                     <DrawerButton
                         key={index}
@@ -84,14 +84,22 @@ define(function (require) {
         // function to render all the childs, wrap each one of them in a div and manage with display
         // which child has to be visible.
         renderMyChildren() {
-            var renderedComponents = this.props.children.map(function(child, index) {
-                if(this.state.drawerOpened == true) {
+            var paddingChildren = 45;
+            var renderedComponents = this.props.children.map(function (child, index) {
+                if (this.state.drawerOpened == true) {
                     var ElementToRender = child;
-                    var MyElement = (this.state.selectedTab != index) ? <div className="hiddenComponent" key={index}><ElementToRender /></div> : <div key={index}><ElementToRender /></div>;
-
+                    if ((this.props.childrenProp[index] != null) && (this.props.childrenProp[index] != undefined)) {
+                        var MyElement = (this.state.selectedTab != index) ? <div className="hiddenComponent" key={index}><ElementToRender iframeHeight={this.state.drawerHeight - paddingChildren} {...this.props.childrenProp[index]} /></div> : <div key={index}><ElementToRender iframeHeight={this.state.drawerHeight - paddingChildren} {...this.props.childrenProp[index]} /></div>;
+                    } else {
+                        var MyElement = (this.state.selectedTab != index) ? <div className="hiddenComponent" key={index}><ElementToRender iframeHeight={this.state.drawerHeight - paddingChildren} /></div> : <div key={index}><ElementToRender iframeHeight={this.state.drawerHeight - paddingChildren} /></div>;
+                    }
                 } else {
                     var ElementToRender = child;
-                    var MyElement = <div key={index}><ElementToRender className="hiddenComponent" /></div>;
+                    if ((this.props.childrenProp[index] != null) && (this.props.childrenProp[index] != undefined)){
+                        var MyElement = <div key={index}><ElementToRender className="hiddenComponent" iframeHeight={this.state.drawerHeight - paddingChildren} {...this.props.childrenProp[index]} /></div>;
+                    } else {
+                        var MyElement = <div key={index}><ElementToRender className="hiddenComponent" iframeHeight={this.state.drawerHeight - paddingChildren} /></div>;
+                    }
                 }
                 return (MyElement);
             }, this);
@@ -100,65 +108,73 @@ define(function (require) {
 
         // Called by the DrawerButton to determine when the drawer has to be open or closed
         openDrawer(buttonClicked) {
-            if(this.state.drawerOpened && (buttonClicked == this.state.selectedTab)) {
-                this.setState({selectedTab: null,
-                               drawerOpened: !this.state.drawerOpened});
-            } else if(this.state.drawerOpened && (buttonClicked != this.state.selectedTab))  {
-                this.setState({selectedTab: buttonClicked});
+            if (this.state.drawerOpened && (buttonClicked == this.state.selectedTab)) {
+                this.setState({
+                    selectedTab: null,
+                    drawerOpened: !this.state.drawerOpened
+                });
+            } else if (this.state.drawerOpened && (buttonClicked != this.state.selectedTab)) {
+                this.setState({ selectedTab: buttonClicked });
             } else {
-                this.setState({selectedTab: buttonClicked,
-                               drawerOpened: !this.state.drawerOpened});
+                this.setState({
+                    selectedTab: buttonClicked,
+                    drawerOpened: !this.state.drawerOpened
+                });
             }
         }
 
         maximizeDrawer() {
             var newOffset = (this.state.drawerHeight >= window.innerHeight - 50) ? 250 : window.innerHeight - 50;
-            this.rnd.updateSize({height: newOffset, width: '100%'});
-            this.setState({drawerHeight: newOffset});
+            this.rnd.updateSize({ height: newOffset, width: '100%' });
+            this.setState({ drawerHeight: newOffset });
         }
 
         closeDrawer() {
-            this.setState({selectedTab: null,
-                           drawerOpened: !this.state.drawerOpened,
-                           drawerHeight: 250});
-            this.rnd.updateSize({height: 250, width: '100%'});
+            this.setState({
+                selectedTab: null,
+                drawerOpened: !this.state.drawerOpened,
+                drawerHeight: 250
+            });
+            this.rnd.updateSize({ height: 250, width: '100%' });
         }
 
         minimizeDrawer() {
-            this.setState({drawerOpened: !this.state.drawerOpened});
+            this.setState({ drawerOpened: !this.state.drawerOpened });
         }
 
         render() {
-            const drawerStyle = this.state.drawerOpened ? {top:null, bottom: 0, display: 'block'} : {display: 'none'};
-            const bottonsStyle = this.state.drawerOpened ? {display: 'block'} : {display: 'none'};
-            const tabStyle = this.state.drawerOpened ? {bottom: this.state.drawerHeight+'px'} : {bottom: '0px'};
+            const drawerStyle = this.state.drawerOpened ? { top: null, bottom: 0, display: 'block' } : { display: 'none' };
+            const bottonsStyle = this.state.drawerOpened ? { display: 'block' } : { display: 'none' };
+            const tabStyle = this.state.drawerOpened ? { bottom: this.state.drawerHeight + 'px' } : { bottom: '0px' };
             return (
                 <div className="geppettoDrawer">
                     <span className="tabber" style={tabStyle}>
                         {this.renderMyLabels()}
                         <div style={bottonsStyle} className="icons">
-                            <div onClick={this.minimizeDrawer} 
-                                 className="minIcons fa fa-chevron-down">
+                            <div onClick={this.minimizeDrawer}
+                                className="minIcons fa fa-chevron-down">
                             </div>
-                            <div onClick={this.maximizeDrawer} 
-                                 className="maxIcons fa fa-chevron-up">
+                            <div onClick={this.maximizeDrawer}
+                                className="maxIcons fa fa-chevron-up">
                             </div>
-                            <div onClick={this.closeDrawer} 
-                                 className="closeIcons fa fa-times">
+                            <div onClick={this.closeDrawer}
+                                className="closeIcons fa fa-times">
                             </div>
                         </div>
                     </span>
-                    <Rnd enableResizing={{ top:true, right:false, bottom:false, left:false, topRight:false, 
-                                           bottomRight:false, bottomLeft:false, topLeft:false }} 
-                         default={{height: 250, width: '100%'}} 
-                         className="drawer" 
-                         style={drawerStyle} 
-                         disableDragging={true} 
-                         onResize={this.drawerResizing} 
-                         onResizeStop={this.drawerStopResizing} 
-                         maxHeight={window.innerHeight - 50} minHeight={250}
-                         ref={c => { this.rnd = c; }} >
-                            {this.renderMyChildren()}
+                    <Rnd enableResizing={{
+                        top: true, right: false, bottom: false, left: false, topRight: false,
+                        bottomRight: false, bottomLeft: false, topLeft: false
+                    }}
+                        default={{ height: 250, width: '100%' }}
+                        className="drawer"
+                        style={drawerStyle}
+                        disableDragging={true}
+                        onResize={this.drawerResizing}
+                        onResizeStop={this.drawerStopResizing}
+                        maxHeight={window.innerHeight - 50} minHeight={250}
+                        ref={c => { this.rnd = c; }} >
+                        {this.renderMyChildren()}
                     </Rnd>
                 </div>
             );

--- a/src/main/webapp/js/components/interface/pythonConsole/PythonConsole.js
+++ b/src/main/webapp/js/components/interface/pythonConsole/PythonConsole.js
@@ -16,34 +16,17 @@ define(function (require) {
      * Creates a table html component used to dipslay the experiments
      */
     var pythonConsole = React.createClass({
-        componentDidMount: function () {
-        	$("#pythonConsoleButton").show();
-
-            $("#pythonConsole").resizable({
-                handles: 'n',
-                minHeight: 100,
-                autoHide: true,
-                maxHeight: 400,
-                resize: function (event, ui) {
-                    if (ui.size.height > ($("#footerHeader").height() * .75)) {
-                        $("#pythonConsole").height($("#footerHeader").height() * .75);
-                        event.preventDefault();
-                    }
-                    $('#pythonConsole').resize();
-                    $("#pythonConsole").get(0).style.top = "0px";
-                }.bind(this)
-            });
-        },
-
-        
-
         render: function () {
 
             return (
                 <div className="col-lg-6 panel-body" id="pythonConsoleOutput">
-                    <iframe id="pythonConsoleFrame" src={this.props.pythonNotebookPath} marginWidth="0" marginHeight="0" frameBorder="no" scrolling="yes" allowTransparency="true" style={{width:'100%', height:'100%'}}>
+                    <iframe id="pythonConsoleFrame" src={this.props["pythonNotebookPath"]} marginWidth="0"
+                                                    marginHeight="0" frameBorder="no" scrolling="yes"
+                                                    allowTransparency="true"
+                                                    style={{width:'100%',
+                                                            height:this.props.iframeHeight+'px'}}>
                    </iframe>
-             	</div>  
+             	</div>
             );
         }
     });


### PR DESCRIPTION
- Fixed text color in js console, primary color was not defined for the input area
- Tabbed Drawer now accepting dynamic parameters that could be expanded in the child component. new prop for child using iframes so that the heigth of the iframe can be re-rendered when required
- Python Console component modified to accept props dynamically, ComponentDidMount not required anymore since the rendering and resizing is driven by the tabbedDrawer itself and when required the rendering is re-triggered from there.

- Nothing done in DrawerButton.js, the code has been just re-formatted.