### PR TITLE
Quick fix to ignore null results

### DIFF
--- a/src/main/webapp/js/components/widgets/stackViewer/StackViewerComponent.js
+++ b/src/main/webapp/js/components/widgets/stackViewer/StackViewerComponent.js
@@ -443,7 +443,7 @@ define(function (require) {
                                                             that.state.objects.push(that.state.label[i]);
                                                         }
                                                     } else {
-                                                        if (typeof that.props.templateDomainIds !== 'undefined' && typeof that.props.templateDomainNames !== 'undefined' && typeof that.props.templateDomainIds[index] !== 'undefined' && typeof that.props.templateDomainNames[index] !== 'undefined') {
+                                                        if (typeof that.props.templateDomainIds !== 'undefined' && typeof that.props.templateDomainNames !== 'undefined' && typeof that.props.templateDomainIds[index] !== 'undefined' && typeof that.props.templateDomainNames[index] !== 'undefined' && that.props.templateDomainNames[index] !== null) {
                                                             that.state.objects.push(that.props.templateDomainNames[index]);
                                                             break;
                                                         }


### PR DESCRIPTION
Resolves a previously missed issue with unlabelled neuropil (previously didn't happen) in L3 template being returned over actually labelled neuropil giving the impression we didn't have labelled content.

Note: This probably warrants quick integration rather than waiting for the float over improvements.

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
