### PR TITLE
Spinner stopped once the commandController detect an issue in the con…

### DIFF
--- a/src/main/webapp/js/components/interface/controlPanel/controlpanel.js
+++ b/src/main/webapp/js/components/interface/controlPanel/controlpanel.js
@@ -1553,6 +1553,7 @@ define(function (require) {
                                     }
                                 } catch (e) {
                                     GEPPETTO.CommandController.log(GEPPETTO.Resources.CONTROL_PANEL_ERROR_RUNNING_SOURCE_SCRIPT + " " + sourceActionStr, true);
+                                    GEPPETTO.trigger(GEPPETTO.Events.Hide_spinner);
                                 }
                             } else {
                                 // if no source assume the record has a property with the column name


### PR DESCRIPTION
related to the trello card https://trello.com/c/4Gt5VYuc/202-2-empty-population-kills-netpyne-ui .

The issue triggered will be handled in another card, the goal of this fix is to avoid that the instatiation process will run forever and the spinner will kill the ui denying to the user the possibility to go back and re-define the netpyne network.