### PR TITLE
querybuilder slick fixed

### DIFF
--- a/src/main/webapp/js/components/interface/query/query.js
+++ b/src/main/webapp/js/components/interface/query/query.js
@@ -12,6 +12,7 @@ define(function (require) {
     var Bloodhound = require("typeahead.js/dist/bloodhound.min.js");
     var Handlebars = require('handlebars');
     var GEPPETTO = require('geppetto');
+    var slick = require('slick-carousel');
 
     var MenuButton = require('../../controls/menuButton/MenuButton');
 


### PR DESCRIPTION
Query builder's slick carousel fix.
