### PR TITLE
handling external severing of connection.

### DIFF
--- a/src/main/webapp/js/communication/MessageSocket.js
+++ b/src/main/webapp/js/communication/MessageSocket.js
@@ -115,7 +115,12 @@ define(function (require) {
                 if (this.isReady() === 1) {
                     GEPPETTO.MessageSocket.socket.send(messageTemplate);
                 }
+                else if (this.isReady() > 1){
+                    // connection is either closing (2) or already closed (3).
+                    GEPPETTO.trigger(GEPPETTO.Events.Websocket_disconnected);
+                }
                 else {
+                    // must be in connecting (0) state
                     var that = this;
                     setTimeout(function () {
                         that.waitForConnection(messageTemplate);


### PR DESCRIPTION
Need to trigger GEPPETTO.Events.Websocket_disconnected when severed by external actors.

Ref https://github.com/VirtualFlyBrain/geppetto-vfb/issues/290

- [ ] Add coverage for whatever new functionality, to a JUnit test if it's backend, to a Casper Test if it's frontend
- [ ] Make sure both push and pr travis builds are passing before asking for a review
