### PR TITLE
use url-join for host in message.socket.connect

### DIFF
--- a/src/main/webapp/js/pages/geppetto/GEPPETTO.Main.js
+++ b/src/main/webapp/js/pages/geppetto/GEPPETTO.Main.js
@@ -11,6 +11,7 @@ define(function (require) {
         var $ = require('jquery');
         var React = require('react');
         var path = require('path');
+        var urljoin = require('url-join');
         var InfoModal = require('../../components/controls/modals/InfoModal');
         var ProjectNode = require('../../geppettoProject/model/ProjectNode');
         var ReactDOM = require('react-dom');
@@ -109,15 +110,15 @@ define(function (require) {
              */
             init: function () {
             	if(GEPPETTO_CONFIGURATION.contextPath=="/"){
-            		var host = path.join(GEPPETTO.MessageSocket.protocol + window.location.host.replace("8081","8080"), '/GeppettoServlet');
+            		var host = urljoin(GEPPETTO.MessageSocket.protocol + window.location.host.replace("8081","8080"), '/GeppettoServlet');
                 }
                 else{
                     var baseHost = GEPPETTO.MessageSocket.protocol + window.location.host;
                     var contextPath = window.location.pathname.substring(0,window.location.pathname.lastIndexOf("/"));
                     if (!contextPath.endsWith(GEPPETTO_CONFIGURATION.contextPath.replace(/^\/|\/$/g, ''))){
-                        contextPath = path.join(contextPath, GEPPETTO_CONFIGURATION.contextPath);
+                        contextPath = urljoin(contextPath, GEPPETTO_CONFIGURATION.contextPath);
                     }
-                    var host = path.join(baseHost, contextPath , "GeppettoServlet")
+                    var host = urljoin(baseHost, contextPath , "GeppettoServlet")
                 }
                 GEPPETTO.MessageSocket.connect(host);
                 console.log("Host for MessageSocket to connect: "+host);

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -99,6 +99,7 @@
     "three-loaders-collada": "^1.0.1",
     "typeahead.js": "^0.11.1",
     "underscore": "^1.8.3",
+    "url-join": "4.0.0",
     "url-loader": "^0.5.8",
     "velocity.java": "^1.3.1",
     "webpack": "3.6.0",


### PR DESCRIPTION
url-join behaviour:

urljoin('wss:', "geppetto") = 'wss://geppetto'
urljoin('wss:/', "geppetto") = 'wss://geppetto'
urljoin('wss://', "/geppetto") = 'wss://geppetto'
urljoin('wss://', "//geppetto") = 'wss://geppetto'

urljoin('wss', "geppetto") = 'wss/geppetto'    <---- without ":"  
urljoin('wss//', "/geppetto") = 'wss/geppetto' 

