### PR TITLE
fix typo in publicPath

### DIFF
--- a/src/main/webapp/webpack.config.js
+++ b/src/main/webapp/webpack.config.js
@@ -14,13 +14,7 @@ try {
     console.error('\nFailed to load Geppetto Configuration')
 }
 
-var publicPath;
-if (geppettoConfig.contextPath == '/') {
-  publicPath = path.join(geppettoConfig.contextPath, "geppetto/build/")
-}
-else {
-  publicPath = path.join("/", geppettoConfig.contextPath, "geppetto/build");
-}
+var publicPath = path.join("/", geppettoConfig.contextPath, "geppetto/build/");
 
 console.log("\nThe public path (used by the main bundle when including split bundles) is: " + publicPath);
 


### PR DESCRIPTION
Casper Tests are passing locally for contextPath = "/" and contextPath = "org.geppetto.frontend"

mvn does not require additional configuration.

Unfortunately, geppetto.ejs is still sensitive to the way we specify contextpath:
line 16
`<base href="<%=htmlWebpackPlugin.options.GEPPETTO_CONFIGURATION.contextPath%>" />`