### PR TITLE
Geppetto application/feature/19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 									<goal>npm</goal>
 								</goals>
 								<configuration>
-									<arguments>install --verbose</arguments>
+									<arguments>install</arguments>
 									<workingDirectory>src/main/webapp</workingDirectory>
 								</configuration>
 							</execution>
@@ -105,7 +105,7 @@
 									<goal>npm</goal>
 								</goals>
 								<configuration>
-									<arguments>install --verbose</arguments>
+									<arguments>install</arguments>
 								</configuration>
 							</execution>
 							<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,9 @@
 	<properties>
 		<contextPath>org.geppetto.frontend</contextPath>
 		<spring.version>4.3.9.RELEASE</spring.version>
+		<useSsl></useSsl>
+		<embedded></embedded>
+		<embedderURL></embedderURL>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,9 @@
 		<contextPath>org.geppetto.frontend</contextPath>
 		<spring.version>4.3.9.RELEASE</spring.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<useSsl></useSsl>
+		<embedded></embedded>
+		<embedderURL></embedderURL>
 	</properties>
 	<profiles>
 		<profile>
@@ -112,7 +115,7 @@
 								</goals>
 								<phase>generate-resources</phase>
 								<configuration>
-									<arguments>run build-dev -- --env.contextPath=${contextPath} --env.useSsl=${useSsl} --env.embedded=${embedded} --env.embedderURL=${embedderURL}</arguments>
+									<arguments>run build  -- --env.contextPath=${contextPath} --env.useSsl=${useSsl} --env.embedded=${embedded} --env.embedderURL=${embedderURL}</arguments>
 								</configuration>
 							</execution>
 						</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,6 @@
 		<contextPath>org.geppetto.frontend</contextPath>
 		<spring.version>4.3.9.RELEASE</spring.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<useSsl></useSsl>
-		<embedded></embedded>
-		<embedderURL></embedderURL>
 	</properties>
 	<profiles>
 		<profile>
@@ -115,7 +112,7 @@
 								</goals>
 								<phase>generate-resources</phase>
 								<configuration>
-									<arguments>run build  -- --env.contextPath=${contextPath} --env.useSsl=${useSsl} --env.embedded=${embedded} --env.embedderURL=${embedderURL}</arguments>
+									<arguments>run build-dev -- --env.contextPath=${contextPath} --env.useSsl=${useSsl} --env.embedded=${embedded} --env.embedderURL=${embedderURL}</arguments>
 								</configuration>
 							</execution>
 						</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 									<goal>npm</goal>
 								</goals>
 								<configuration>
-									<arguments>install</arguments>
+									<arguments>install --verbose</arguments>
 									<workingDirectory>src/main/webapp</workingDirectory>
 								</configuration>
 							</execution>
@@ -105,7 +105,7 @@
 									<goal>npm</goal>
 								</goals>
 								<configuration>
-									<arguments>install</arguments>
+									<arguments>install --verbose</arguments>
 								</configuration>
 							</execution>
 							<execution>


### PR DESCRIPTION
Mvn install fails in windows due to not finding 'useSSL, embedderURL, and embedded' properties declared in pom.xml. In Unix systems this doesn't seem to be a problem, but in windows it breaks the installation.

The command using these properties is :
`<arguments>run build  -- --env.contextPath=${contextPath} --env.useSsl=${useSsl} --env.embedded=${embedded} --env.embedderURL=${embedderURL}</arguments>
`
