### PR TITLE
Backend websocket reconnection

### DIFF
--- a/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
+++ b/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
@@ -241,7 +241,8 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 	 * @param requestID
 	 * @param projectId
 	 */
-	public void setProjectFromId(String requestID, long projectId) {
+	public void setProjectFromId(String requestID, long projectId) 
+	{
 		try {
 			IGeppettoDataManager dataManager = DataManagerHelper.getDataManager();
 			IGeppettoProject geppettoProject = dataManager.getGeppettoProjectById(projectId);
@@ -410,7 +411,6 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 	public void reloadExperiment(String requestID, long experimentID, long projectId)
 	{
 		long start = System.currentTimeMillis();
-		// websocketConnection.sendMessage(requestID, OutboundMessages.EXPERIMENT_LOADING, "");
 		try
 		{
 			IGeppettoProject geppettoProject = retrieveGeppettoProject(projectId);
@@ -419,7 +419,6 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 			if(experiment != null)
 			{
 				ExperimentState experimentState = geppettoManager.loadExperiment(requestID, experiment);
-				// websocketConnection.sendMessage(requestID, OutboundMessages.EXPERIMENT_LOADED, GeppettoSerializer.serializeToJSON(experimentState));
 				logger.info("The experiment " + experimentID + " was reloaded");
 
 			}

--- a/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
+++ b/src/main/java/org/geppetto/frontend/controllers/ConnectionHandler.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -83,7 +84,7 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 
 	// the geppetto project active for this connection
 	private IGeppettoProject geppettoProject;
-
+	
 	/**
 	 * @param websocketConnection
 	 * @param geppettoManager
@@ -98,7 +99,32 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 		this.geppettoManager = new GeppettoManager(geppettoManager, geppettoManagerConfiguration);
 		this.geppettoManager.setSimulationListener(this);
 	}
-
+	
+	/**
+	 * @param instance
+	 */
+	public void setGeppettoManager(GeppettoManager instance) throws GeppettoExecutionException
+	{
+		if (instance != null) {
+			geppettoManager = instance;
+		} else {
+			throw new GeppettoExecutionException("Setting geppetto manager on reconnection not working, the instance provided is null");
+		}
+	}
+	
+	/**
+	 * @return
+	 * @throws GeppettoExecutionException 
+	 */
+	public IGeppettoManager getGeppettoManager() throws GeppettoExecutionException
+	{
+		if (geppettoManager != null) {
+			return geppettoManager;
+		} else {
+			throw new GeppettoExecutionException("This connection handler does not have an initialised geppetto manager.");
+		}
+	}
+	
 	/**
 	 * @param requestID
 	 * @param projectId
@@ -209,6 +235,28 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 			error(e, "Could not load geppetto project");
 		}
 
+	}
+	
+	/**
+	 * @param requestID
+	 * @param projectId
+	 */
+	public void setProjectFromId(String requestID, long projectId) {
+		try {
+			IGeppettoDataManager dataManager = DataManagerHelper.getDataManager();
+			IGeppettoProject geppettoProject = dataManager.getGeppettoProjectById(projectId);
+
+			Gson gson = new Gson();
+			String projectJSON = gson.toJson(geppettoProject);
+			boolean persisted = geppettoProject.isVolatile();
+			String update = "{\"project\":" + projectJSON + "}";
+
+			setConnectionProject(geppettoProject);
+			reloadExperiment(requestID, geppettoProject.getActiveExperimentId(), projectId);
+			websocketConnection.sendMessage(null, OutboundMessages.PROJECT_LOADED, update);
+		} catch (GeppettoExecutionException e) {
+			error(e, "Error in retrieving the project from the ID provided");
+		}
 	}
 
 	/**
@@ -348,6 +396,40 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 			error(e, "Error loading experiment");
 		}
 		catch(IOException e)
+		{
+			error(e, "Error loading experiment");
+		}
+		logger.debug("Loading experiment took " + (System.currentTimeMillis() - start) + "ms");
+	}
+	
+	/**
+	 * @param requestID
+	 * @param experimentID
+	 * @param projectId
+	 */
+	public void reloadExperiment(String requestID, long experimentID, long projectId)
+	{
+		long start = System.currentTimeMillis();
+		// websocketConnection.sendMessage(requestID, OutboundMessages.EXPERIMENT_LOADING, "");
+		try
+		{
+			IGeppettoProject geppettoProject = retrieveGeppettoProject(projectId);
+			IExperiment experiment = retrieveExperiment(experimentID, geppettoProject);
+			// run the matched experiment
+			if(experiment != null)
+			{
+				ExperimentState experimentState = geppettoManager.loadExperiment(requestID, experiment);
+				// websocketConnection.sendMessage(requestID, OutboundMessages.EXPERIMENT_LOADED, GeppettoSerializer.serializeToJSON(experimentState));
+				logger.info("The experiment " + experimentID + " was reloaded");
+
+			}
+			else
+			{
+				error(null, "Error reloading experiment, the experiment " + experimentID + " was not found in project " + projectId);
+			}
+
+		}
+		catch(GeppettoExecutionException | GeppettoAccessException e)
 		{
 			error(e, "Error loading experiment");
 		}
@@ -1411,6 +1493,14 @@ public class ConnectionHandler implements IGeppettoManagerCallbackListener
 
 	}
 
+	/**
+	 * 
+	 */
+	public void pauseProject()
+	{
+		ConnectionsManager.getInstance().removeConnection(websocketConnection);
+
+	}
 	/**
 	 * @param geppettoProject
 	 * @throws GeppettoExecutionException

--- a/src/main/java/org/geppetto/frontend/controllers/WebsocketConnection.java
+++ b/src/main/java/org/geppetto/frontend/controllers/WebsocketConnection.java
@@ -232,7 +232,6 @@ public class WebsocketConnection extends Endpoint implements MessageSenderListen
 					projectId = Long.parseLong(parameters.get("projectId"));
 					try {
 						connectionHandler.setGeppettoManager(ConnectionsManager.getInstance().getHandler(lostConnectionID));
-						// connectionHandler.setProjectFromId(requestID, projectId);
 					} catch (GeppettoExecutionException e) {
 						sendMessage(requestID, OutboundMessages.RECONNECTION_ERROR, "");
 					}

--- a/src/main/java/org/geppetto/frontend/messages/InboundMessages.java
+++ b/src/main/java/org/geppetto/frontend/messages/InboundMessages.java
@@ -10,6 +10,7 @@ public enum InboundMessages {
 	NOTIFY_USER("notify_user"),
 	GET_SCRIPT("get_script"),
 	GET_DATA_SOURCE_RESULTS("get_data_source_results"),
+	RECONNECT("reconnect"),
 	
 	//PROJECT MESSAGES
 	LOAD_PROJECT_FROM_URL("load_project_from_url"), 
@@ -53,7 +54,7 @@ public enum InboundMessages {
 	
 	//QUERIES
 	RUN_QUERY("run_query"),
-	RUN_QUERY_COUNT("run_query_count"),
+	RUN_QUERY_COUNT("run_query_count"), 
 	;
 
 	

--- a/src/main/java/org/geppetto/frontend/messages/OutboundMessages.java
+++ b/src/main/java/org/geppetto/frontend/messages/OutboundMessages.java
@@ -61,7 +61,8 @@ public enum OutboundMessages {
 	IMPORT_VALUE_RESOLVED("import_value_resolved"),
 	RETURN_QUERY("return_query"),
 	RETURN_QUERY_COUNT("return_query_count"), 
-	RETURN_QUERY_RESULTS("return_query_results");
+	RETURN_QUERY_RESULTS("return_query_results"),
+	RECONNECTION_ERROR("reconnection_error");
 
 	private OutboundMessages(final String text) {
 		this.text = text;


### PR DESCRIPTION
# Backend websocket reconnection

Backend wise, the logic is based on the assumption that we need to save the previous geppetto manager instantiated in the first websocket session since this contains all the information added to the model before the connection will be dropped, differently if we handle only the websocket logic and we reconnect and instantiate a new ConnectionHandler and consequentially a new GeppettoManager this will let us use geppetto to add stuff Ui wise but if we request something that was already supposed to be in the model the whole UI will get crazy (massively out of synch and plenty of geppetto dialogs triggered by cascade errors).

For this reason as soon the onClose method is triggered we check the event status code, if legit we simply remove the project and close this connection, otherwise we save the current GeppettoManager through a set of getter and setter introduced in these changes and we park this a ConcurrentHashMap, stored in the singleton ConnectionsManager.
This is stored with the connectionID as key, so when the frontend will realise that the connection has been dropped will send a reconnect to retrieve the geppettoManager from the previous connection that has been dropped. Here the backend will check if we stored this GeppettoManager, and if present will plug this in the current ConnectionHandler and remove it from the map struct.

Also, when we store the GeppettoManager in the concurrentHashMap, we store also the timestamp in seconds from UTC, everytime a new connection is instantiated we check the connections that have been dropped and now we also check the GeppettoManager parked in memory more than 5 mins, in that case we remove these to avoid to fill up the memory with no remorse.

This address the issue #901 
(the branch has been called fix/177 by mistake since I opened this on the geppetto-client first, if necessary I can rename this).